### PR TITLE
Adds randomization in testint order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ install:
   - pip install pep8 --use-mirrors
   - pip install https://github.com/dcramer/pyflakes/tarball/master
   - pip install .
+  - pip install pytest-random
 # command to run tests
 script:
     - pep8 cli
     - pep8 tests
-    - py.test tests -v
+    - py.test tests -v --random

--- a/cli/conf.py
+++ b/cli/conf.py
@@ -3,8 +3,9 @@ import ConfigParser
 import clg
 import os
 import yaml
-from cli import exceptions
-from cli import utils
+
+import cli.exceptions
+import cli.utils
 
 ENV_VAR_NAME = "IR_CONFIG"
 IR_CONF_FILE = 'infrared.cfg'
@@ -35,7 +36,7 @@ def load_config_file():
             return _config
 
     conf_file_paths = "\n".join([CWD_PATH, USER_PATH, SYSTEM_PATH])
-    raise exceptions.IRFileNotFoundException(
+    raise cli.exceptions.IRFileNotFoundException(
         conf_file_paths,
         "IR configuration not found. "
         "Please set it in one of the following paths:\n")
@@ -59,7 +60,7 @@ class SpecManager(object):
         res = {}
         for spec_file in self.__get_all_specs(subfolder=module_name):
             spec = yaml.load(open(spec_file))
-            utils.dict_merge(res, spec)
+            cli.utils.dict_merge(res, spec)
         return res
 
     def parse_args(self, module_name):
@@ -71,7 +72,7 @@ class SpecManager(object):
         return cmd.parse()
 
     def __get_all_specs(self, subfolder=None):
-        root_dir = utils.validate_settings_dir(
+        root_dir = cli.utils.validate_settings_dir(
             self.config.get('defaults', 'settings'))
         if subfolder:
             root_dir = os.path.join(root_dir, subfolder)

--- a/cli/conf.py
+++ b/cli/conf.py
@@ -4,15 +4,8 @@ import clg
 import os
 import yaml
 
-import cli.exceptions
-import cli.utils
-
-ENV_VAR_NAME = "IR_CONFIG"
-IR_CONF_FILE = 'infrared.cfg'
-CWD_PATH = os.path.join(os.getcwd(), IR_CONF_FILE)
-USER_PATH = os.path.expanduser('~/.' + IR_CONF_FILE)
-SYSTEM_PATH = os.path.join('/etc/infrared', IR_CONF_FILE)
-INFRARED_DIR_ENV_VAR = 'IR_SETTINGS'
+from cli import exceptions
+from cli import utils
 
 
 def load_config_file():
@@ -22,21 +15,22 @@ def load_config_file():
     """
 
     # create a parser with default path to InfraRed's main dir
+    cwd_path = os.path.join(os.getcwd(), utils.IR_CONF_FILE)
     _config = ConfigParser.ConfigParser()
 
-    env_path = os.getenv(ENV_VAR_NAME, None)
+    env_path = os.getenv(utils.ENV_VAR_NAME, None)
     if env_path is not None:
         env_path = os.path.expanduser(env_path)
         if os.path.isdir(env_path):
-            env_path = os.path.join(env_path, IR_CONF_FILE)
+            env_path = os.path.join(env_path, utils.IR_CONF_FILE)
 
-    for path in (env_path, CWD_PATH, USER_PATH, SYSTEM_PATH):
+    for path in (env_path, cwd_path, utils.USER_PATH, utils.SYSTEM_PATH):
         if path is not None and os.path.exists(path):
             _config.read(path)
             return _config
 
-    conf_file_paths = "\n".join([CWD_PATH, USER_PATH, SYSTEM_PATH])
-    raise cli.exceptions.IRFileNotFoundException(
+    conf_file_paths = "\n".join([cwd_path, utils.USER_PATH, utils.SYSTEM_PATH])
+    raise exceptions.IRFileNotFoundException(
         conf_file_paths,
         "IR configuration not found. "
         "Please set it in one of the following paths:\n")
@@ -60,7 +54,7 @@ class SpecManager(object):
         res = {}
         for spec_file in self.__get_all_specs(subfolder=module_name):
             spec = yaml.load(open(spec_file))
-            cli.utils.dict_merge(res, spec)
+            utils.dict_merge(res, spec)
         return res
 
     def parse_args(self, module_name):
@@ -72,7 +66,7 @@ class SpecManager(object):
         return cmd.parse()
 
     def __get_all_specs(self, subfolder=None):
-        root_dir = cli.utils.validate_settings_dir(
+        root_dir = utils.validate_settings_dir(
             self.config.get('defaults', 'settings'))
         if subfolder:
             root_dir = os.path.join(root_dir, subfolder)

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -9,7 +9,6 @@ import configure
 import yaml
 
 import cli.yamls
-import cli.conf
 from cli import exceptions
 from cli import logger
 
@@ -64,7 +63,7 @@ def validate_settings_dir(settings_dir=None):
             exist
     """
     settings_dir = settings_dir or os.environ.get(
-        cli.conf.INFRARED_DIR_ENV_VAR)
+        utils.INFRARED_DIR_ENV_VAR)
 
     if not os.path.exists(settings_dir):
         raise exceptions.IRFileNotFoundException(
@@ -152,3 +151,10 @@ def normalize_file(file_path):
         raise exceptions.IRFileNotFoundException(file_path)
 
     return file_path
+
+
+ENV_VAR_NAME = "IR_CONFIG"
+IR_CONF_FILE = 'infrared.cfg'
+USER_PATH = os.path.expanduser('~/.' + IR_CONF_FILE)
+SYSTEM_PATH = os.path.join('/etc/infrared', IR_CONF_FILE)
+INFRARED_DIR_ENV_VAR = 'IR_SETTINGS'


### PR DESCRIPTION
This patch adds an installation of 'pytest-random' PyPi package which
adds the ability to run the unittests in random order.
when running with '-v/--verbose' flag, the seed will be printed to
stdout to allow running in same order if want (--random-seed=xxxxx must
come with --random)

resolves #9 