### PR TITLE
ENTRY_POINT derived from tool command

### DIFF
--- a/cli/conf.py
+++ b/cli/conf.py
@@ -2,10 +2,17 @@ import ConfigParser
 
 import clg
 import os
+import sys
 import yaml
 
 from cli import exceptions
 from cli import utils
+
+ENTRY_POINT = dict(
+    provision='provisioner',
+    install='installer',
+    test='tester'
+)[sys.argv[0].split('-')[-1]]
 
 
 def load_config_file():
@@ -78,5 +85,6 @@ class SpecManager(object):
                 res.append(os.path.join(dirpath, filename))
 
         return res
+
 
 config = load_config_file()

--- a/cli/install.py
+++ b/cli/install.py
@@ -12,8 +12,6 @@ from cli import utils
 import cli.yamls
 import cli.execute
 
-ENTRY_POINT = "installer"
-
 LOG = logger.LOG
 CONF = conf.config
 
@@ -31,8 +29,7 @@ def get_settings_dir(args=None):
     settings_dir = utils.validate_settings_dir(
         CONF.get('defaults', 'settings'))
     if args:
-        settings_dir = os.path.join(settings_dir,
-                                    ENTRY_POINT)
+        settings_dir = os.path.join(settings_dir, conf.ENTRY_POINT)
     if hasattr(args, "command0"):
         settings_dir = os.path.join(settings_dir,
                                     args['command0'])
@@ -45,7 +42,7 @@ def get_args(args=None):
     """
 
     spec_manager = conf.SpecManager(CONF)
-    args = spec_manager.parse_args(ENTRY_POINT, args=args)
+    args = spec_manager.parse_args(conf.ENTRY_POINT, args=args)
     return args
 
 

--- a/cli/provision.py
+++ b/cli/provision.py
@@ -12,13 +12,8 @@ from cli.install import get_args, get_settings_dir, set_logger_verbosity
 import cli.yamls
 import cli.execute
 
-ENTRY_POINT = "provisioner"
-
 LOG = logger.LOG
 CONF = conf.config
-
-NON_SETTINGS_OPTIONS = ['command0', 'verbose', 'extra-vars', 'output-file',
-                        'input-files', 'dry-run', 'cleanup', 'inventory']
 
 
 def main():


### PR DESCRIPTION
RNTRY_POINT is now defined in conf.py by the tool name (sys.argv)
and isn't depended on the module where functions call it.