### PR TITLE
Add settings for new provisioner - openstack

### DIFF
--- a/settings/provisioner/openstack/defaults.ini
+++ b/settings/provisioner/openstack/defaults.ini
@@ -1,0 +1,6 @@
+[openstack]
+topology=all-in-one.yml
+site=qeos7.yml
+network=default.yml
+ssh-key=~/.ssh/id_rsa
+ssh-user=root

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -1,0 +1,48 @@
+---
+subparsers:
+    openstack:
+        help: Provision systems using Ansible OpenStack modules
+        groups:
+            - title: image
+              options:
+                  image-file:
+                      type: str
+                      help: An image to provision the hosts with
+                  image-server:
+                      type: str
+                      help: Base URL of the image file server
+            - title: topology
+              options:
+                  topology:
+                      type: str
+                      help: 'Provision topology (default: __DEFAULT__)'
+            - title: site
+              options:
+                  topology:
+                      type: str
+                      help: The site where the nodes will be provisioned
+            - title: common
+              options:
+                  dry-run:
+                      action: store_true
+                      help: Only generate settings, skip the playbook execution stage
+                  cleanup:
+                      action: store_true
+                      help: Clean given system instead of provisioning a new one
+                  input:
+                      action: append
+                      type: str
+                      short: i
+                      help: Input settings file to be loaded before the merging of user args
+                  output:
+                      type: str
+                      short: o
+                      help: 'File to dump the generated settings into (default: stdout)'
+                  extra-vars:
+                      action: append
+                      short: e
+                      help: Extra variables to be merged last
+                      type: str
+                  from-file:
+                      type: IniFile
+                      help: the ini file with the list of arguments

--- a/settings/provisioner/openstack/openstack.yml
+++ b/settings/provisioner/openstack/openstack.yml
@@ -1,0 +1,26 @@
+---
+
+provisioner:
+    type: openstack
+
+    image:
+        memory: "16384"
+        cpu: "4"
+        os:
+            variant: rhel7
+        disk:
+            size: "40G"
+
+distro:
+    name: rhel
+    full_version: "7.2"
+    version:
+        major: '7'
+        minor: '2'
+
+job:
+  archive:
+  - /var/log/
+  - /etc/yum.repos.d
+  - /etc/selinux
+  - /root/

--- a/settings/provisioner/openstack/site/qeos7.yml
+++ b/settings/provisioner/openstack/site/qeos7.yml
@@ -1,0 +1,37 @@
+provisioner:
+    ssh_timeout: 900 
+    auth_url: !lookup private.provisioner.qeos7.auth_url
+
+    network:
+        domain: ""
+        type: neutron
+        name: public
+
+    flavor:
+        tiny:
+            name: 'm1.tiny'
+            id: 1
+        small:
+            name: 'm1.small'
+            id: 2
+        medium:
+            name: 'm1.medium'
+            id: 3
+        large:
+            name: 'm1.large'
+            id: 4
+        large_testing:
+            name: 'm1.large_testing'
+            id: c6e0ad85-81a8-4fbb-a2d9-b0abac52f79b
+        large_ephemeral:
+            name: 'm1.large_ephemeral'
+            id: a89c1587-aab2-49c2-a60d-4d19ea40bdbc
+        medlarge:
+            name: 'm1.medlarge'
+            id: d4cb47aa-9278-4762-9d89-b8c6693a46e9
+        xlarge:
+            name: 'm1.xlarge'
+            id: 5
+        c1xlarge:
+            name: 'c1.xlarge'
+            id: 500

--- a/settings/provisioner/openstack/topology/all-in-one.yml
+++ b/settings/provisioner/openstack/topology/all-in-one.yml
@@ -1,0 +1,39 @@
+---
+provisioner:
+    nodes:
+        controller: &controller
+            name: controller
+            amount: 1
+            cpu: "{{ !lookup provisioner.image.cpu }}"
+            memory: 16384
+            os:
+                type: linux
+                variant: "{{ !lookup provisioner.image.os.variant }}"
+            disks:
+                disk1: &disk1
+                    path: /var/lib/libvirt/images
+                    dev: /dev/vda
+                    size: 20G
+            network: &network_params
+                interfaces: &interfaces
+                    data: &data_interface
+                        label: eth1
+                        config_params: &data_interface_params
+                            bootproto: static
+                            ipaddr: 10.0.0.1
+                            netmask: 255.255.255.0
+                            nm_controlled: "no"
+                            type: ethernet
+                            onboot: yes
+                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.data.label }}"
+                    external: &external_interface
+                        label: eth2
+                        config_params:
+                            <<: *data_interface_params
+                            ipaddr: ""
+                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.external.label }}"
+            groups:
+                - controller
+                - compute
+                - network
+                - openstack_nodes


### PR DESCRIPTION
Added settings for new provisioner 'openstack'.

The provisioner will allow to lunch instances on existing openstack
clouds, using Ansible cloud modules.