### PR TITLE
[RHOSINFRA-65] - Vlan fix

### DIFF
--- a/playbooks/installer/ospd/overcloud/templates/overcloud_deploy.sh.j2
+++ b/playbooks/installer/ospd/overcloud/templates/overcloud_deploy.sh.j2
@@ -8,7 +8,8 @@ openstack overcloud deploy --debug \
                        --neutron-network-type {{ installer.overcloud.network.backend }} \
 {% if installer.overcloud.network.backend == "vlan" %}
                        --neutron-disable-tunneling \
-                       --neutron-network-vlan-ranges {{ installer.undercloud.config.physical_network }}:1000:2000 \
+                       --neutron-bridge-mappings {{ installer.undercloud.config.physical_network }}:br-ex,tenant:br-isolated \
+                       --neutron-network-vlan-ranges tenant:1000:2000 \
 {% else %}
                        --neutron-tunnel-types {{ installer.overcloud.network.backend }} \
 {% endif %}

--- a/settings/installer/ospd/network/isolation/protocol/ipv4.yml
+++ b/settings/installer/ospd/network/isolation/protocol/ipv4.yml
@@ -27,3 +27,4 @@ installer:
                         ControlPlaneDefaultRoute: 172.16.0.1
                         EC2MetadataIp: 172.16.0.1
                         DnsServers: ['192.168.1.1', '8.8.8.8']
+                        NeutronExternalNetworkBridge: "''"

--- a/settings/installer/ospd/network/isolation/protocol/ipv6.yml
+++ b/settings/installer/ospd/network/isolation/protocol/ipv6.yml
@@ -28,3 +28,4 @@ installer:
                         ControlPlaneDefaultRoute: 172.16.0.1
                         EC2MetadataIp: 172.16.0.1
                         DnsServers: ['192.168.1.1', '8.8.8.8']
+                        NeutronExternalNetworkBridge: "''"


### PR DESCRIPTION
This patch fixes the issue where the vlan was not configured properly
on a three-nic-isolation deployment.