### PR TITLE
RHOSINFRA-63 Auto nesting of input arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!*j2
 nosetests.xml
 ansible.cfg
 *.py[co]

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,18 @@ The merging priority order is:
 
 InfraRed input arguments
 ------------------------
+
+.. note:: The following mechanism applies to special argument types that need
+ to be defined in `.spec` files:
+
+#. **Value**: String values
+#. **YamlFile**: Expects path to YAML files. Will search for files in the settings directory before trying to resolve
+   absolute path. For the argument name is "arg-name" and of subparser "SUBCOMMAND" of command "COMMAND", the default
+   search path would be::
+
+    settings_dir/COMMAND/SUBCOMMAND/arg/name/arg_value
+
+
 InfraRed accepts the next sources of the input arguments (in priority order):
 
 1. Command line arguments:  ``ir-provision virsh --host=some.host.com --ssh_user=root``
@@ -117,7 +129,7 @@ There are two steps that should be done when adding a new plugin to InfraRed:
     For more details on how to use this module, please visit the 'clg' module `homepage <http://clg.readthedocs
     .org/en/latest/>`_.
 
-2. Creating a default spec file (default.ini). 
+2. Creating a default spec file (default.ini).
     This file should contain the default values for the command line arguments. All the default values should go under the name section names as a new plugin. Example::
       
       [virsh]

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -79,6 +79,28 @@ def dict_merge(first, second, path=None,
     return first
 
 
+def search_tree(haystack, needle, _res=None):
+    """Find all values of key `needle` inside a nested dict tree `haystack`.
+
+    :param haystack: nested dict tree to search
+    :param needle: key name to search for
+    :param _res: helper argument holding return value for internal recursion
+    :return: list. All values of key `needle` in tree `haystack`. Order is not
+        guaranteed.
+    """
+    if _res is None:
+        _res = []
+    if needle in haystack:
+        _res.append(haystack[needle])
+    for key, value in haystack.iteritems():
+        if isinstance(value, dict):
+            search_tree(value, needle, _res)
+        if isinstance(value, list):
+            for item in value:
+                search_tree(item, needle, _res)
+    return _res
+
+
 # TODO: remove "settings" references in project
 def validate_settings_dir(settings_dir=None):
     """Checks & returns the full path to the settings dir.

--- a/playbooks/installer/ospd/overcloud/pre.yml
+++ b/playbooks/installer/ospd/overcloud/pre.yml
@@ -183,7 +183,7 @@
         register: flavor_result
         when: "'{{ item.key }}' != 'undercloud'"
         failed_when: "result.rc != 0 and result.stderr.find('Flavor with name {{ item.key }} already exists') != -1"
-        with_dict: provisioner.nodes
+        with_dict: provisioner.virsh.topology.nodes
 
       - set_fact:
             tagged_flavors: "{{ flavor_result.results }}"

--- a/playbooks/installer/ospd/overcloud/pre.yml
+++ b/playbooks/installer/ospd/overcloud/pre.yml
@@ -48,7 +48,7 @@
       - name: SSH copy ID to the hypervisor
         become: yes
         become_user: "{{ installer.user.name }}"
-        shell: "sshpass -p '{{ installer.user.password }}' ssh-copy-id {{ installer.user.name }}@{{ provisioner.network.network_list.management.ip_address }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        shell: "sshpass -p '{{ installer.user.password }}' ssh-copy-id {{ installer.user.name }}@{{ provisioner.virsh.network.management.ip_address }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
         delegate_to: undercloud
 
       - name: "DEBUG - print mac addresses for hosts - DEBUG"

--- a/playbooks/installer/ospd/overcloud/run.yml
+++ b/playbooks/installer/ospd/overcloud/run.yml
@@ -18,7 +18,7 @@
             dest: "~/overcloud_deploy.sh"
             mode: 0755
   roles:
-      - {role: "ospd/overcloud/storage/ceph/", when: provisioner.nodes.ceph is defined or installer.overcloud.storage.external == "yes"}
+      - {role: "ospd/overcloud/storage/ceph/", when: provisioner.virsh.topology.nodes.ceph is defined or installer.overcloud.storage.external == "yes"}
       - {role: "ospd/overcloud/network/isolation/{{ installer.overcloud.network.isolation.type }}/", when: installer.overcloud.network.isolation.enable == "yes"}
       - {role: "ospd/overcloud/ssl/", when: installer.overcloud.use_ssl == "yes"}
 

--- a/playbooks/installer/ospd/overcloud/templates/ssh.config.ansible.j2
+++ b/playbooks/installer/ospd/overcloud/templates/ssh.config.ansible.j2
@@ -2,7 +2,7 @@
 {% for host in groups['all'] %}
 {% if hostvars[host].get('ansible_connection', '') != 'local' and host != 'virthost' %}
 Host {{ host }}
-    ProxyCommand ssh -i {{ provisioner.hosts.host1.ssh_key_file }} {{ provisioner.hosts.host1.ssh_user }}@{{ provisioner.hosts.host1.ssh_host }} nc %h %p
+    ProxyCommand ssh -i {{ provisioner.virsh.host.key }} {{ provisioner.virsh.host.user }}@{{ provisioner.virsh.host.address }} nc %h %p
     HostName {{ hostvars[host].ansible_default_ipv4.address }}
 {% if host == 'undercloud' %}
     User root

--- a/playbooks/installer/ospd/overcloud/templates/virthost_instack.json.j2
+++ b/playbooks/installer/ospd/overcloud/templates/virthost_instack.json.j2
@@ -2,14 +2,14 @@
   "ssh-user": "{{ installer.user.name }}",
   "ssh-key": "$(cat ~/.ssh/id_rsa)",
   "power_manager": "nova.virt.baremetal.virtual_power_driver.VirtualPowerManager",
-  "host-ip": "{{ provisioner.network.network_list.management.ip_address }}",
+  "host-ip": "{{ provisioner.virsh.network.management.ip_address }}",
   "arch": "x86_64",
   "nodes": [
 {% for host_name in groups['openstack_nodes'] %}
     {% if host_name != 'undercloud' %}
     {
       "name": "{{ hostvars[host_name].inventory_hostname }}",
-      "pm_addr": "{{ provisioner.network.network_list.management.ip_address }}",
+      "pm_addr": "{{ provisioner.virsh.network.management.ip_address }}",
       "pm_password": "$(cat ~/.ssh/id_rsa)",
       "pm_type": "pxe_ssh",
       "mac": ["{{ hostvars[host_name]['ansible_%s' % installer.undercloud.config.local_interface].macaddress }}"],

--- a/playbooks/installer/ospd/overcloud/templates/virthost_instack.json.j2
+++ b/playbooks/installer/ospd/overcloud/templates/virthost_instack.json.j2
@@ -13,9 +13,9 @@
       "pm_password": "$(cat ~/.ssh/id_rsa)",
       "pm_type": "pxe_ssh",
       "mac": ["{{ hostvars[host_name]['ansible_%s' % installer.undercloud.config.local_interface].macaddress }}"],
-      "cpu": "{{ provisioner.nodes[host_name.rstrip('1234567890')].cpu }}",
-      "memory": "{{ provisioner.nodes[host_name.rstrip('1234567890')].memory }}",
-      "disk": "{{ provisioner.nodes[host_name.rstrip('1234567890')].disks.disk1.size | regex_replace('(?P<size>[0-9]+).*$', '\\g<size>') }}",
+      "cpu": "{{ provisioner.virsh.topology.nodes[host_name.rstrip('1234567890')].cpu }}",
+      "memory": "{{ provisioner.virsh.topology.nodes[host_name.rstrip('1234567890')].memory }}",
+      "disk": "{{ provisioner.virsh.topology.nodes[host_name.rstrip('1234567890')].disks.disk1.size | regex_replace('(?P<size>[0-9]+).*$', '\\g<size>') }}",
       "arch": "x86_64",
       "pm_user": "{{ installer.user.name }}"
     }{% if not loop.last %},{% endif %}

--- a/playbooks/provision.yaml
+++ b/playbooks/provision.yaml
@@ -33,22 +33,6 @@
         state: link
         src: "{{ lookup('env', 'PWD') }}/hosts-{{ lookup('env', 'USER') }}"
 
-- name: extend hosts file
-  hosts: openstack_nodes
-  gather_facts: no
-  sudo: yes
-  tasks:
-    - name: Template of nodes
-      template:
-        dest: "/tmp/ansible_hosts"
-        src: provisioner/templates/hosts.j2
-      register: templatehosts
-      when: provisioner.network.domain is defined
-
-    - name: Update hosts file
-      shell: "cat /tmp/ansible_hosts >> /etc/hosts"
-      when: templatehosts|changed
-
 - name: Break point
   hosts: localhost
   tasks:

--- a/playbooks/provisioner/templates/hosts.j2
+++ b/playbooks/provisioner/templates/hosts.j2
@@ -1,5 +1,0 @@
-{% for host in groups['all'] %}
-{% if hostvars[host].get('ansible_connection', '') != 'local' %}
-{{ hostvars[host]['ansible_ssh_host'] }} {{ host }} {{ host }}{{ provisioner.network.domain }}
-{% endif %}
-{% endfor %}

--- a/playbooks/provisioner/virsh/cleanup.yaml
+++ b/playbooks/provisioner/virsh/cleanup.yaml
@@ -2,15 +2,17 @@
 - name: Add host to host list
   hosts: localhost
   gather_facts: no
+  vars:
+      hypervisor: "{{ provisioner.virsh.host }}"
   tasks:
       - name: add hosts to host list
         add_host:
-            name="{{ item.value.name }}"
-            groups="{{ item.value.groups| join(',') }}"
+            name="{{ hypervisor.name }}"
+            groups="{{ hypervisor.groups| join(',') }}"
             node_label="{{ item.key }}"
-            ansible_ssh_user="{{ item.value.ssh_user }}"
-            ansible_ssh_host="{{ item.value.ssh_host }}"
-            ansible_ssh_private_key_file="{{ item.value.ssh_key_file }}"
+            ansible_ssh_user="{{ hypervisor.user }}"
+            ansible_ssh_host="{{ hypervisor.address }}"
+            ansible_ssh_private_key_file="{{ hypervisor.key }}"
         with_dict: provisioner.hosts
 
 - name: Remove all VMs and networks that were created

--- a/playbooks/provisioner/virsh/cleanup.yaml
+++ b/playbooks/provisioner/virsh/cleanup.yaml
@@ -54,7 +54,7 @@
         virt_net:
             name: "{{ item.value.name }}"
             state: absent
-        with_dict: provisioner.network.network_list
+        with_dict: provisioner.virsh.network
 
       - name: remove any existing disks that we created
         shell: "rm -f {{ item.key }}*disk*.qcow*"

--- a/playbooks/provisioner/virsh/cleanup.yaml
+++ b/playbooks/provisioner/virsh/cleanup.yaml
@@ -60,4 +60,4 @@
         shell: "rm -f {{ item.key }}*disk*.qcow*"
         args:
             chdir: "/var/lib/libvirt/images"
-        with_dict: provisioner.nodes
+        with_dict: provisioner.virsh.topology.nodes

--- a/playbooks/provisioner/virsh/main.yaml
+++ b/playbooks/provisioner/virsh/main.yaml
@@ -154,19 +154,19 @@
             name: "{{ item.value.name }}"
             xml: "{{ lookup('template', 'network/network.xml.j2') }}"
         when: "item.value.name not in network_list.list_nets"
-        with_dict: provisioner.network.network_list
+        with_dict: provisioner.virsh.network
 
       - name: check if network is active
         virt_net:
             state: active
             name: "{{ item.value.name }}"
-        with_dict: provisioner.network.network_list
+        with_dict: provisioner.virsh.network
 
       - name: make network persistent
         virt_net:
             autostart: "yes"
             name: "{{ item.value.name }}"
-        with_dict: provisioner.network.network_list
+        with_dict: provisioner.virsh.network
 
       - name: remove pre-existing file
         file:
@@ -217,17 +217,17 @@
         shell: "virsh domiflist {{ item[0] }} | awk '/{{ item[1] }}/ {print $5};'"
         with_nested:
             - vm_name_list
-            - provisioner.network.network_list
+            - provisioner.virsh.network
         register: mac_list
 
       - set_fact:
             vm_mac_list: "{{ mac_list.results }}"
 
       - name: wait until one of the VMs gets an IP
-        shell: "virsh net-dhcp-leases {{ provisioner.network.network_list['%s' % item.item[1]].name }} | awk /{{ item.stdout }}/'{print $5}' | cut -d'/' -f1"
+        shell: "virsh net-dhcp-leases {{ provisioner.virsh.network['%s' % item.item[1]].name }} | awk /{{ item.stdout }}/'{print $5}' | cut -d'/' -f1"
         when: item.stdout != ""
         register: ip_list
-        until: ip_list.stdout.find("{{ provisioner.network.network_list['%s' % item.item[1]].ip_address | truncate(7, True, '') }}") > -1
+        until: ip_list.stdout.find("{{ provisioner.virsh.network['%s' % item.item[1]].ip_address | truncate(7, True, '') }}") > -1
         retries: 40
         delay: 5
         with_items: vm_mac_list
@@ -249,7 +249,7 @@
         shell: "virsh net-update {{ item[0] }} add ip-dhcp-host \"<host mac='{{ item[1].item.stdout }}' name='{{ item[1].item.item[0] }}' ip='{{ item[1].stdout }}' />\" --live --config"
         when: item[1].item is defined and item[1].item.item[1] == item[0]
         with_nested:
-            - provisioner.network.network_list
+            - provisioner.virsh.network
             - vm_ip_list
 
       - name: copy created key from virthost for SSH proxy

--- a/playbooks/provisioner/virsh/main.yaml
+++ b/playbooks/provisioner/virsh/main.yaml
@@ -2,15 +2,17 @@
 - name: Add host to host list
   hosts: localhost
   gather_facts: no
+  vars:
+      hypervisor: "{{ provisioner.virsh.host }}"
   tasks:
       - name: add hosts to host list
         add_host:
-            name="{{ item.value.name }}"
-            groups="{{ item.value.groups| join(',') }}"
+            name="{{ hypervisor.name }}"
+            groups="{{ hypervisor.groups| join(',') }}"
             node_label="{{ item.key }}"
-            ansible_ssh_user="{{ item.value.ssh_user }}"
-            ansible_ssh_host="{{ item.value.ssh_host }}"
-            ansible_ssh_private_key_file="{{ item.value.ssh_key_file }}"
+            ansible_ssh_user="{{ hypervisor.user }}"
+            ansible_ssh_host="{{ hypervisor.address }}"
+            ansible_ssh_private_key_file="{{ hypervisor.key }}"
         with_dict: provisioner.hosts
 
 - name: Install dependencies

--- a/playbooks/provisioner/virsh/main.yaml
+++ b/playbooks/provisioner/virsh/main.yaml
@@ -171,12 +171,12 @@
       - name: remove pre-existing file
         file:
             state: absent
-            dest: "/var/lib/libvirt/images/{{ provisioner.image.name }}-original"
+            dest: "/var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original"
 
       - name: download base guest image
         get_url:
-            dest: "/var/lib/libvirt/images/{{ provisioner.image.name }}-original"
-            url: "{{ provisioner.image.base_url }}/{{ provisioner.image.name }}"
+            dest: "/var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original"
+            url: "{{ provisioner.virsh.image.server }}/{{ provisioner.virsh.image.file }}"
         register: result
         until: result.msg.find("Request failed") == -1
         retries: 5

--- a/playbooks/provisioner/virsh/main.yaml
+++ b/playbooks/provisioner/virsh/main.yaml
@@ -238,7 +238,7 @@
       - name: add hosts to host list
         add_host:
             name="{{ item.item.item[0] }}"
-            groups="{{ provisioner.nodes['%s' % item.item.item[0].rstrip('1234567890')].groups | join(',') }}"
+            groups="{{ provisioner.virsh.topology.nodes['%s' % item.item.item[0].rstrip('1234567890')].groups | join(',') }}"
             ansible_ssh_user="root"
             ansible_ssh_password="redhat"
             ansible_ssh_host="{{ item.stdout }}"

--- a/playbooks/provisioner/virsh/templates/create_images.sh.j2
+++ b/playbooks/provisioner/virsh/templates/create_images.sh.j2
@@ -1,27 +1,27 @@
 #!/bin/bash
 
 # Clean our guest image
-virt-sysprep /var/lib/libvirt/images/{{ provisioner.image.name }}-original --operations dhcp-client-state,dhcp-server-state,net-hostname,net-hwaddr,udev-persistent-net
+virt-sysprep /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original --operations dhcp-client-state,dhcp-server-state,net-hostname,net-hwaddr,udev-persistent-net
 
 # reset the password to a default one
-virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original --root-password password:redhat
+virt-customize -a /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original --root-password password:redhat
 
 # Removing cloud-init
-virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original --run-command 'yum remove cloud-init* -y'
+virt-customize -a /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original --run-command 'yum remove cloud-init* -y'
 
 # TODO: configure interfaces based on config rather than hardcode
 # configure three network interfaces for the image
-virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original --run-command 'cp /etc/sysconfig/network-scripts/ifcfg-eth{0,1} && sed -i s/DEVICE=.*/DEVICE=eth1/g /etc/sysconfig/network-scripts/ifcfg-eth1'
+virt-customize -a /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original --run-command 'cp /etc/sysconfig/network-scripts/ifcfg-eth{0,1} && sed -i s/DEVICE=.*/DEVICE=eth1/g /etc/sysconfig/network-scripts/ifcfg-eth1'
 
 # TODO: configure interfaces based on config rather than hardcode
 # configure three network interfaces for the image
-virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original --run-command 'cp /etc/sysconfig/network-scripts/ifcfg-eth{1,2} && sed -i s/DEVICE=.*/DEVICE=eth2/g /etc/sysconfig/network-scripts/ifcfg-eth2'
+virt-customize -a /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original --run-command 'cp /etc/sysconfig/network-scripts/ifcfg-eth{1,2} && sed -i s/DEVICE=.*/DEVICE=eth2/g /etc/sysconfig/network-scripts/ifcfg-eth2'
 
 {% for node_name, node_values in provisioner.virsh.topology.nodes.iteritems() %}
 {% for num in range(1, node_values.amount + 1, 1) %}
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
 qemu-img create -f qcow2 {{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2 {{ disk_values.size }}
 {% endfor %}
-virt-resize --expand /dev/sda1 /var/lib/libvirt/images/{{ provisioner.image.name }}-original {{ node_values.disks.disk1.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.disk1.qcow2
+virt-resize --expand /dev/sda1 /var/lib/libvirt/images/{{ provisioner.virsh.image.name }}-original {{ node_values.disks.disk1.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.disk1.qcow2
 {% endfor %}
 {% endfor %}

--- a/playbooks/provisioner/virsh/templates/create_images.sh.j2
+++ b/playbooks/provisioner/virsh/templates/create_images.sh.j2
@@ -17,7 +17,7 @@ virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original 
 # configure three network interfaces for the image
 virt-customize -a /var/lib/libvirt/images/{{ provisioner.image.name }}-original --run-command 'cp /etc/sysconfig/network-scripts/ifcfg-eth{1,2} && sed -i s/DEVICE=.*/DEVICE=eth2/g /etc/sysconfig/network-scripts/ifcfg-eth2'
 
-{% for node_name, node_values in provisioner.nodes.iteritems() %}
+{% for node_name, node_values in provisioner.virsh.topology.nodes.iteritems() %}
 {% for num in range(1, node_values.amount + 1, 1) %}
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
 qemu-img create -f qcow2 {{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2 {{ disk_values.size }}

--- a/playbooks/provisioner/virsh/templates/create_vms.sh.j2
+++ b/playbooks/provisioner/virsh/templates/create_vms.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{% for node_name, node_values in provisioner.nodes.iteritems() %}
+{% for node_name, node_values in provisioner.virsh.topology.nodes.iteritems() %}
 {% for num in range(1, node_values.amount + 1, 1) %}
 virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %} \
 {% for disk_name, disk_values in node_values.disks.iteritems() %}

--- a/playbooks/provisioner/virsh/templates/create_vms.sh.j2
+++ b/playbooks/provisioner/virsh/templates/create_vms.sh.j2
@@ -5,9 +5,9 @@ virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% en
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
              --disk path={{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2 \
 {% endfor %}
-             --network network:{{ provisioner.network.network_list.data.name }} \
-             --network network:{{ provisioner.network.network_list.management.name }} \
-             --network network:{{ provisioner.network.network_list.external.name }} \
+             --network network:{{ provisioner.virsh.network.data.name }} \
+             --network network:{{ provisioner.virsh.network.management.name }} \
+             --network network:{{ provisioner.virsh.network.external.name }} \
              --virt-type kvm \
              --cpu host-model \
              --ram {{ node_values.memory }} \

--- a/playbooks/provisioner/virsh/templates/ssh.config.ansible.j2
+++ b/playbooks/provisioner/virsh/templates/ssh.config.ansible.j2
@@ -1,7 +1,7 @@
 {% for host in groups['all'] %}
 {% if hostvars[host].get('ansible_connection', '') != 'local' and host != 'virthost' %}
 Host {{ host }}
-    ProxyCommand ssh -i {{ provisioner.hosts.host1.ssh_key_file }} {{ provisioner.hosts.host1.ssh_user }}@{{ provisioner.hosts.host1.ssh_host }} nc %h %p
+    ProxyCommand ssh -i {{ provisioner.virsh.host.key }} {{ provisioner.virsh.host.user }}@{{ provisioner.virsh.host.address }} nc %h %p
     HostName {{ hostvars[host].ansible_ssh_host }}
     User root
     IdentityFile {{ inventory_dir }}/id_rsa

--- a/roles/ospd/overcloud/storage/ceph/templates/ceph.yml.j2
+++ b/roles/ospd/overcloud/storage/ceph/templates/ceph.yml.j2
@@ -12,7 +12,7 @@ resource_registry:
 {% else %}
     ExtraConfig:
       ceph::profile::params::osds:
-{% for disk_name, disk_values in provisioner.nodes.ceph.disks.iteritems() %}
+{% for disk_name, disk_values in provisioner.virsh.topology.nodes.ceph.disks.iteritems() %}
 {% if disk_name != 'disk1' %}
        '{{ disk_values.dev }}':
            journal: ''

--- a/settings/provisioner/virsh/default.ini
+++ b/settings/provisioner/virsh/default.ini
@@ -1,5 +1,5 @@
 [virsh]
 topology=all-in-one.yml
 network=default.yml
-ssh-key=~/.ssh/id_rsa
-ssh-user=root
+host-key=~/.ssh/id_rsa
+host-user=root

--- a/settings/provisioner/virsh/network/default.yml
+++ b/settings/provisioner/virsh/network/default.yml
@@ -1,40 +1,38 @@
 ---
 
-provisioner:
-    network:
-        network_list:
-            # todo: same as hyp
-            data:
-                name: "provisioning"
-                ip_address: "172.16.0.254"
-                netmask: "255.255.255.0"
-            management:
-                name: "management"
-                ip_address: "10.0.0.1"
-                netmask: "255.255.255.0"
-                forward:
-                    type: "nat"
-                dhcp:
-                    range:
-                        start: "10.0.0.2"
-                        end: "10.0.0.100"
-                    subnet_cidr: "10.0.0.0/24"
-                    subnet_gateway: "10.0.0.1"
-                floating_ip:
-                    start: "10.0.0.101"
-                    end: "10.0.0.150"
-            external:
-                name: "external"
-                ip_address: "192.168.1.1"
-                netmask: "255.255.255.0"
-                forward:
-                    type: "nat"
-                dhcp:
-                    range:
-                        start: "192.168.1.2"
-                        end: "192.168.1.100"
-                    subnet_cidr: "192.168.1.0/24"
-                    subnet_gateway: "192.168.1.1"
-                floating_ip:
-                    start: "192.168.1.101"
-                    end: "192.168.1.150"
+network_list:
+    # todo: same as hyp
+    data:
+        name: "provisioning"
+        ip_address: "172.16.0.254"
+        netmask: "255.255.255.0"
+    management:
+        name: "management"
+        ip_address: "10.0.0.1"
+        netmask: "255.255.255.0"
+        forward:
+            type: "nat"
+        dhcp:
+            range:
+                start: "10.0.0.2"
+                end: "10.0.0.100"
+            subnet_cidr: "10.0.0.0/24"
+            subnet_gateway: "10.0.0.1"
+        floating_ip:
+            start: "10.0.0.101"
+            end: "10.0.0.150"
+    external:
+        name: "external"
+        ip_address: "192.168.1.1"
+        netmask: "255.255.255.0"
+        forward:
+            type: "nat"
+        dhcp:
+            range:
+                start: "192.168.1.2"
+                end: "192.168.1.100"
+            subnet_cidr: "192.168.1.0/24"
+            subnet_gateway: "192.168.1.1"
+        floating_ip:
+            start: "192.168.1.101"
+            end: "192.168.1.150"

--- a/settings/provisioner/virsh/topology/README.txt
+++ b/settings/provisioner/virsh/topology/README.txt
@@ -6,13 +6,13 @@ nodes:
     example:
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disk: &disk
-            size: "{{ !lookup provisioner.image.disk.size }}"
+            size: "{{ !lookup provisioner.virsh.image.disk.size }}"
             dev: /dev/vda
             path: /var/lib/libvirt/images
         network: &network_params

--- a/settings/provisioner/virsh/topology/README.txt
+++ b/settings/provisioner/virsh/topology/README.txt
@@ -1,31 +1,30 @@
 This is a placeholder for the new provisioner to hold the topology files
 in the form of:
 
-provisioner:
-    nodes:
-        # Dict of nodes
-        example:
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disk: &disk
-                size: "{{ !lookup provisioner.image.disk.size }}"
-                dev: /dev/vda
-                path: /var/lib/libvirt/images
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    # Dict of nodes
+    example:
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disk: &disk
+            size: "{{ !lookup provisioner.image.disk.size }}"
+            dev: /dev/vda
+            path: /var/lib/libvirt/images
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
 

--- a/settings/provisioner/virsh/topology/all-in-one.yml
+++ b/settings/provisioner/virsh/topology/all-in-one.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 16384
         os:
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks:
             disk1: &disk1
                 path: /var/lib/libvirt/images

--- a/settings/provisioner/virsh/topology/all-in-one.yml
+++ b/settings/provisioner/virsh/topology/all-in-one.yml
@@ -1,39 +1,38 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 16384
-            os:
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    data: &data_interface
-                        label: eth1
-                        config_params: &data_interface_params
-                            bootproto: static
-                            ipaddr: 10.0.0.1
-                            netmask: 255.255.255.0
-                            nm_controlled: "no"
-                            type: ethernet
-                            onboot: yes
-                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.data.label }}"
-                    external: &external_interface
-                        label: eth2
-                        config_params:
-                            <<: *data_interface_params
-                            ipaddr: ""
-                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.external.label }}"
-            groups:
-                - controller
-                - compute
-                - network
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 16384
+        os:
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                data: &data_interface
+                    label: eth1
+                    config_params: &data_interface_params
+                        bootproto: static
+                        ipaddr: 10.0.0.1
+                        netmask: 255.255.255.0
+                        nm_controlled: "no"
+                        type: ethernet
+                        onboot: yes
+                        device: "{{ !lookup provisioner.virsh.topology.nodes.controller.network.interfaces.data.label }}"
+                external: &external_interface
+                    label: eth2
+                    config_params:
+                        <<: *data_interface_params
+                        ipaddr: ""
+                        device: "{{ !lookup provisioner.virsh.topology.nodes.controller.network.interfaces.external.label }}"
+        groups:
+            - controller
+            - compute
+            - network
+            - openstack_nodes

--- a/settings/provisioner/virsh/topology/multi-node.yml
+++ b/settings/provisioner/virsh/topology/multi-node.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 16384
         os:
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks:
             disk1: &disk1
                 path: /var/lib/libvirt/images

--- a/settings/provisioner/virsh/topology/multi-node.yml
+++ b/settings/provisioner/virsh/topology/multi-node.yml
@@ -1,88 +1,87 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 16384
-            os:
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    data: &data_interface
-                        label: eth1
-                        config_params: &data_interface_params
-                            bootproto: static
-                            ipaddr: 10.0.0.1
-                            netmask: 255.255.255.0
-                            nm_controlled: "no"
-                            type: ethernet
-                            onboot: yes
-                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.data.label }}"
-                    external: &external_interface
-                        label: eth2
-                        config_params:
-                            <<: *data_interface_params
-                            ipaddr: ""
-                            device: "{{ !lookup provisioner.nodes.controller.network.interfaces.external.label }}"
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 16384
+        os:
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                data: &data_interface
+                    label: eth1
+                    config_params: &data_interface_params
+                        bootproto: static
+                        ipaddr: 10.0.0.1
+                        netmask: 255.255.255.0
+                        nm_controlled: "no"
+                        type: ethernet
+                        onboot: yes
+                        device: "{{ !lookup provisioner.virsh.topology.nodes.controller.network.interfaces.data.label }}"
+                external: &external_interface
+                    label: eth2
+                    config_params:
+                        <<: *data_interface_params
+                        ipaddr: ""
+                        device: "{{ !lookup provisioner.virsh.topology.nodes.controller.network.interfaces.external.label }}"
+        groups:
+            - controller
+            - openstack_nodes
 
+    network:
+        <<: *controller
+        name: '{{ tmp.node_prefix }}network'
         network:
-            <<: *controller
-            name: '{{ tmp.node_prefix }}network'
-            network:
-                <<: *network_params
-                interfaces:
-                    <<: *interfaces
-                    data:
-                        <<: *data_interface
-                        config_params:
-                            <<: *data_interface_params
-                            ipaddr: 10.0.0.2
+            <<: *network_params
+            interfaces:
+                <<: *interfaces
+                data:
+                    <<: *data_interface
+                    config_params:
+                        <<: *data_interface_params
+                        ipaddr: 10.0.0.2
 
-            groups:
-                - openstack_nodes
-                - network
+        groups:
+            - openstack_nodes
+            - network
 
-        compute1:
-            <<: *controller
-            name: '{{ tmp.node_prefix }}compute1'
-            network:
-                <<: *network_params
-                interfaces:
-                    <<: *interfaces
-                    data:
-                        <<: *data_interface
-                        config_params:
-                            <<: *data_interface_params
-                            ipaddr: 10.0.0.3
+    compute1:
+        <<: *controller
+        name: '{{ tmp.node_prefix }}compute1'
+        network:
+            <<: *network_params
+            interfaces:
+                <<: *interfaces
+                data:
+                    <<: *data_interface
+                    config_params:
+                        <<: *data_interface_params
+                        ipaddr: 10.0.0.3
 
-            groups:
-                - openstack_nodes
-                - compute
+        groups:
+            - openstack_nodes
+            - compute
 
-        compute2:
-            <<: *controller
-            name: '{{ tmp.node_prefix }}compute2'
-            network:
-                <<: *network_params
-                interfaces:
-                    <<: *interfaces
-                    data:
-                        <<: *data_interface
-                        config_params:
-                            <<: *data_interface_params
-                            ipaddr: 10.0.0.4
+    compute2:
+        <<: *controller
+        name: '{{ tmp.node_prefix }}compute2'
+        network:
+            <<: *network_params
+            interfaces:
+                <<: *interfaces
+                data:
+                    <<: *data_interface
+                    config_params:
+                        <<: *data_interface_params
+                        ipaddr: 10.0.0.4
 
-            groups:
-                - openstack_nodes
-                - compute
+        groups:
+            - openstack_nodes
+            - compute

--- a/settings/provisioner/virsh/topology/ospd_1cont_1comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_1comp.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -43,7 +43,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         groups:
             - undercloud
             - tester

--- a/settings/provisioner/virsh/topology/ospd_1cont_1comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_1comp.yml
@@ -1,52 +1,51 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 30G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 30G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute
-            amount: 1
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute
+        amount: 1
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_1cont_1comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_1comp_1ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1:
                 path: /var/lib/libvirt/images
@@ -67,7 +67,7 @@ nodes:
     undercloud:
         <<: *controller
         name: undercloud
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         groups:
             - undercloud
             - tester

--- a/settings/provisioner/virsh/topology/ospd_1cont_1comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_1comp_1ceph.yml
@@ -1,76 +1,75 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 30G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 30G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute
-            amount: 1
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute
+        amount: 1
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 1
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-                disk3:
-                    <<: *disk1
-                    dev: /dev/vdc
-                disk4:
-                    <<: *disk1
-                    dev: /dev/vdd
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 1
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+            disk3:
+                <<: *disk1
+                dev: /dev/vdc
+            disk4:
+                <<: *disk1
+                dev: /dev/vdd
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            memory: "{{ !lookup provisioner.image.memory }}"
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        memory: "{{ !lookup provisioner.image.memory }}"
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp.yml
@@ -1,52 +1,51 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 30G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 30G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -43,7 +43,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         groups:
             - undercloud
             - tester

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp_1ceph.yml
@@ -1,76 +1,75 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 30G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 30G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 1
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-                disk3:
-                    <<: *disk1
-                    dev: /dev/vdc
-                disk4:
-                    <<: *disk1
-                    dev: /dev/vdd
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 1
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+            disk3:
+                <<: *disk1
+                dev: /dev/vdc
+            disk4:
+                <<: *disk1
+                dev: /dev/vdd
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            memory: "{{ !lookup provisioner.image.memory }}"
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        memory: "{{ !lookup provisioner.image.memory }}"
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp_1ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1:
                 path: /var/lib/libvirt/images
@@ -67,7 +67,7 @@ nodes:
     undercloud:
         <<: *controller
         name: undercloud
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         groups:
             - undercloud
             - tester

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp_3ceph.yml
@@ -1,70 +1,69 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 1
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 30G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 1
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 30G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/sda1
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/sda1
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 3
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 3
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            memory: "{{ !lookup provisioner.image.memory }}"
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        memory: "{{ !lookup provisioner.image.memory }}"
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_1cont_2comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_1cont_2comp_3ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 1
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1:
                 path: /var/lib/libvirt/images
@@ -61,7 +61,7 @@ nodes:
     undercloud:
         <<: *controller
         name: undercloud
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         groups:
             - undercloud
             - tester

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -43,7 +43,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp.yml
@@ -1,57 +1,56 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 1
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 1
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp_1ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1:
                 path: /var/lib/libvirt/images
@@ -67,7 +67,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp_1ceph.yml
@@ -1,81 +1,80 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 1
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 1
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 1
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-                disk3:
-                    <<: *disk1
-                    dev: /dev/vdc
-                disk4:
-                    <<: *disk1
-                    dev: /dev/vdd
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 1
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+            disk3:
+                <<: *disk1
+                dev: /dev/vdc
+            disk4:
+                <<: *disk1
+                dev: /dev/vdd
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp_3ceph.yml
@@ -1,75 +1,74 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 1
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 1
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 3
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 3
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_1comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_1comp_3ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -61,7 +61,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp.yml
@@ -1,57 +1,56 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -43,7 +43,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp_1ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1:
                 path: /var/lib/libvirt/images
@@ -67,7 +67,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp_1ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp_1ceph.yml
@@ -1,81 +1,80 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 1
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    <<: *disk1
-                    dev: /dev/vdb
-                disk3:
-                    <<: *disk1
-                    dev: /dev/vdc
-                disk4:
-                    <<: *disk1
-                    dev: /dev/vdd
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 1
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                <<: *disk1
+                dev: /dev/vdb
+            disk3:
+                <<: *disk1
+                dev: /dev/vdc
+            disk4:
+                <<: *disk1
+                dev: /dev/vdd
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp_3ceph.yml
@@ -1,76 +1,75 @@
 ---
-provisioner:
-    nodes:
-        controller: &controller
-            name: controller
-            amount: 3
-            cpu: "{{ !lookup provisioner.image.cpu }}"
-            memory: 8192
-            os: &os
-                type: linux
-                variant: "{{ !lookup provisioner.image.os.variant }}"
-            disks: &disks
-                disk1: &disk1
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-            network: &network_params
-                interfaces: &interfaces
-                    management: &mgmt_interface
-                        label: eth0
-                    data: &data_interface
-                        label: eth1
-                    external: &external_interface
-                        label: eth2
-            groups:
-                - controller
-                - openstack_nodes
+nodes:
+    controller: &controller
+        name: controller
+        amount: 3
+        cpu: "{{ !lookup provisioner.image.cpu }}"
+        memory: 8192
+        os: &os
+            type: linux
+            variant: "{{ !lookup provisioner.image.os.variant }}"
+        disks: &disks
+            disk1: &disk1
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+        network: &network_params
+            interfaces: &interfaces
+                management: &mgmt_interface
+                    label: eth0
+                data: &data_interface
+                    label: eth1
+                external: &external_interface
+                    label: eth2
+        groups:
+            - controller
+            - openstack_nodes
 
-        compute:
-            <<: *controller
-            name: compute1
-            amount: 2
-            cpu: 2
-            memory: 6144
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    size: 20G
-            groups:
-                - compute
-                - openstack_nodes
+    compute:
+        <<: *controller
+        name: compute1
+        amount: 2
+        cpu: 2
+        memory: 6144
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                size: 20G
+        groups:
+            - compute
+            - openstack_nodes
 
-        ceph:
-            <<: *controller
-            name: ceph
-            amount: 3
-            cpu: 2
-            memory: 4096
-            disks:
-                disk1:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vda
-                    size: 20G
-                disk2:
-                    path: /var/lib/libvirt/images
-                    dev: /dev/vdb
-                    size: 20G
-            groups:
-                - ceph
-                - openstack_nodes
+    ceph:
+        <<: *controller
+        name: ceph
+        amount: 3
+        cpu: 2
+        memory: 4096
+        disks:
+            disk1:
+                path: /var/lib/libvirt/images
+                dev: /dev/vda
+                size: 20G
+            disk2:
+                path: /var/lib/libvirt/images
+                dev: /dev/vdb
+                size: 20G
+        groups:
+            - ceph
+            - openstack_nodes
 
-        undercloud:
-            <<: *controller
-            name: undercloud
-            amount: 1
-            memory: "{{ !lookup provisioner.image.memory }}"
-            disks:
-                <<: *disks
-                disk1:
-                    <<: *disk1
-                    size: 20G
-            groups:
-                - undercloud
-                - tester
-                - openstack_nodes
+    undercloud:
+        <<: *controller
+        name: undercloud
+        amount: 1
+        memory: "{{ !lookup provisioner.image.memory }}"
+        disks:
+            <<: *disks
+            disk1:
+                <<: *disk1
+                size: 20G
+        groups:
+            - undercloud
+            - tester
+            - openstack_nodes
 

--- a/settings/provisioner/virsh/topology/ospd_3cont_2comp_3ceph.yml
+++ b/settings/provisioner/virsh/topology/ospd_3cont_2comp_3ceph.yml
@@ -3,11 +3,11 @@ nodes:
     controller: &controller
         name: controller
         amount: 3
-        cpu: "{{ !lookup provisioner.image.cpu }}"
+        cpu: "{{ !lookup provisioner.virsh.image.cpu }}"
         memory: 8192
         os: &os
             type: linux
-            variant: "{{ !lookup provisioner.image.os.variant }}"
+            variant: "{{ !lookup provisioner.virsh.image.os.variant }}"
         disks: &disks
             disk1: &disk1
                 path: /var/lib/libvirt/images
@@ -62,7 +62,7 @@ nodes:
         <<: *controller
         name: undercloud
         amount: 1
-        memory: "{{ !lookup provisioner.image.memory }}"
+        memory: "{{ !lookup provisioner.virsh.image.memory }}"
         disks:
             <<: *disks
             disk1:

--- a/settings/provisioner/virsh/virsh.spec
+++ b/settings/provisioner/virsh/virsh.spec
@@ -4,15 +4,15 @@ subparsers:
         help: Provision systems using virsh
         #argument_default: null
         groups:
-            - title: host
+            - title: Hypervisor
               options:
-                  host:
+                  host-address:
                       type: Value
                       help: Address/FQDN of the BM hypervisor
-                  ssh-user:
+                  host-user:
                       type: Value
                       help: User to SSH to the host with
-                  ssh-key:
+                  host-key:
                       type: Value
                       help: "User's SSH key"
             - title: image

--- a/settings/provisioner/virsh/virsh.spec
+++ b/settings/provisioner/virsh/virsh.spec
@@ -2,33 +2,34 @@
 subparsers:
     virsh:
         help: Provision systems using virsh
+        #argument_default: null
         groups:
             - title: host
               options:
                   host:
-                      type: str
+                      type: Value
                       help: Address/FQDN of the BM hypervisor
                   ssh-user:
-                      type: str
+                      type: Value
                       help: User to SSH to the host with
                   ssh-key:
-                      type: str
+                      type: Value
                       help: "User's SSH key"
             - title: image
               options:
                   image-file:
-                      type: str
+                      type: Value
                       help: An image to provision the host with
                   image-server:
-                      type: str
+                      type: Value
                       help: Base URL of the image file server
             - title: topology
               options:
                   network:
-                      type: str
+                      type: YamlFile
                       help: Network
                   topology:
-                      type: str
+                      type: YamlFile
                       help: 'Provision topology (default: __DEFAULT__)'
             - title: common
               options:

--- a/settings/provisioner/virsh/virsh.yml
+++ b/settings/provisioner/virsh/virsh.yml
@@ -8,6 +8,13 @@ provisioner:
             name: virthost
             groups:
                 - virthost
+        image:
+            memory: "16384"
+            cpu: "4"
+            os:
+                variant: rhel7
+            disk:
+                size: "40G"
 
     packages:
         - libvirt
@@ -21,13 +28,6 @@ provisioner:
         - libguestfs-xfs
         - sshpass
 
-    image:
-        memory: "16384"
-        cpu: "4"
-        os:
-            variant: rhel7
-        disk:
-            size: "40G"
 
 distro:
     name: rhel

--- a/settings/provisioner/virsh/virsh.yml
+++ b/settings/provisioner/virsh/virsh.yml
@@ -3,8 +3,8 @@
 provisioner:
     type: virsh
 
-    hosts:
-        host1:
+    virsh:
+        host:
             name: virthost
             groups:
                 - virthost

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,3 +13,43 @@ def test_dict_insert(tested, val, key, expected):
     from cli import utils
     utils.dict_insert(tested, val, *key)
     assert tested == expected
+
+
+@pytest.mark.parametrize("haystack, output", [
+    ({}, []),
+    ({"needle": "val1",
+      "bad": "input"}, ["val1"]),
+    ({"needle": "val1",
+      "bad": "input",
+      "nested1": {"needle": "val2", "differnt": "values"}
+      }, ["val1", "val2"]),
+    ({"needle": "val1",
+      "bad": "input",
+      "nested2": {"netsted3":
+                      {"needle": "val3",
+                       "differnt": "values"}},
+      "nested1": {"needle": "val2", "differnt": "values"}
+      }, ["val1", "val2", "val3"]),
+    ({"bad": "input",
+      "needle": {"netsted3":
+                      {"needle": "val3",
+                       "differnt": "values"}},
+      "nested1": {"needle": "val2", "differnt": "values"}
+      }, ["val2", "val3",
+          {"netsted3": {"needle": "val3", "differnt": "values"}}]),
+    ({"bad": "input",
+      "list": [{"needle": {"netsted3": {"needle": "val3",
+                                        "differnt": "values"}},
+                "nested1": {"needle": "val2", "differnt": "values"}}]
+      }, ["val2", "val3",
+          {"netsted3": {"needle": "val3", "differnt": "values"}}])
+
+])
+def test_search_tree(haystack, output):
+    from utils import search_tree
+
+    result = search_tree(haystack, "needle")
+    # can't make set of dict, but we still don't care about order
+    assert len(result) == len(output)
+    for item in output:
+        assert item in result


### PR DESCRIPTION
RHOSINFRA-63 RHOSINFRA-22 Auto nesting of input arguments.

Arguments will now populate the settings tree automatically by mapping
of argument name to a nested dict.

Example:
The input `$ ir-COMMAND SUBCOMMAND --arg-name=arg-value` will be map:

```yaml
    COMMAND:
        SUBCOMMAND:
            arg:
                name: "arg-value"
```
That nested dict will be merged into the settings YAML found in:

  `settings/COMMAND/SUBCOMMAND/SUBCOMMAND.yaml`

Based on the spec file:

  `settings/COMMAND/SUBCOMMAND/SUBCOMMAND.spec`

Adds ValueArgument to clg types. Arguments of these type can reslove
defaults according to documentation: If not provided in CLI, search in
ENV vars and later in given ini file.

Adds YamlFileArgument that will load YAMLS from given paths directly as
dict. Default search path for the argument from the above example would
be:

  `$ ir-COMMAND SUBCOMMAND --arg-name=path/to/file.yaml`
  `settings_dir/COMMAND/SUBCOMMAND/arg/name/path/to/file/yaml`

Adds search_tree method to search all values of a given key inside a
nested dict tree.
Adds unittest for method
