### PR TITLE
 RHOSINFRA-52 Add 'openstack' provisioner

### DIFF
--- a/library/os_floating_ip.py
+++ b/library/os_floating_ip.py
@@ -182,7 +182,8 @@ def main():
 
             cloud.add_ips_to_server(
                 server=server, ips=floating_ip_address, reuse=reuse,
-                fixed_address=fixed_address, wait=wait, timeout=timeout)
+                ip_pool=network, fixed_address=fixed_address, wait=wait,
+                timeout=timeout)
             fip_address = cloud.get_server_public_ip(server)
             # Update the floating IP status
             f_ip = _get_floating_ip(cloud, fip_address)

--- a/library/os_floating_ip.py
+++ b/library/os_floating_ip.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+# Author: Davide Guerri <davide.guerri@hp.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    from shade import meta
+
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_floating_ip
+version_added: "2.0"
+short_description: Add/Remove floating IP from an instance
+extends_documentation_fragment: openstack
+description:
+   - Add or Remove a floating IP to an instance
+options:
+   server:
+     description:
+        - The name or ID of the instance to which the IP address
+          should be assigned.
+     required: true
+   network:
+     description:
+        - The name or ID of a neutron external network or a nova pool name.
+     required: false
+   internal_network:
+     description:
+        - The name or ID of a neutron internal network of the port.
+     required: false
+   floating_ip_address:
+     description:
+        - A floating IP address to attach or to detach. Required only if state
+          is absent. When state is present can be used to specify a IP address
+          to attach.
+     required: false
+   reuse:
+     description:
+        - When state is present, and floating_ip_address is not present,
+          this parameter can be used to specify whether we should try to reuse
+          a floating IP address already allocated to the project.
+     required: false
+     default: false
+   fixed_address:
+     description:
+        - To which fixed IP of server the floating IP address should be
+          attached to.
+     required: false
+   wait:
+     description:
+        - When attaching a floating IP address, specify whether we should
+          wait for it to appear as attached.
+     required: false
+     default: false
+   timeout:
+     description:
+        - Time to wait for an IP address to appear as attached. See wait.
+     required: false
+     default: 60
+   state:
+     description:
+       - Should the resource be present or absent.
+     choices: [present, absent]
+     required: false
+     default: present
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Assign a floating IP to the fist interface of `cattle001` from an exiting
+# external network or nova pool. A new floating IP from the first available
+# external network is allocated to the project.
+- os_floating_ip:
+     cloud: dguerri
+     server: cattle001
+
+# Assign a new floating IP to the instance fixed ip `192.0.2.3` of
+# `cattle001`. If a free floating IP is already allocated to the project, it is
+# reused; if not, a new one is created.
+- os_floating_ip:
+     cloud: dguerri
+     state: present
+     reuse: yes
+     server: cattle001
+     network: ext_net
+     fixed_address: 192.0.2.3
+     wait: true
+     timeout: 180
+
+# Detach a floating IP address from a server
+- os_floating_ip:
+     cloud: dguerri
+     state: absent
+     floating_ip_address: 203.0.113.2
+     server: cattle001
+'''
+
+
+def _get_floating_ip(cloud, floating_ip_address):
+    f_ips = cloud.search_floating_ips(
+        filters={'floating_ip_address': floating_ip_address})
+    if not f_ips:
+        return None
+
+    return f_ips[0]
+
+
+def main():
+    argument_spec = openstack_full_argument_spec(
+        server=dict(required=True),
+        state=dict(default='present', choices=['absent', 'present']),
+        network=dict(required=False, default=None),
+        floating_ip_address=dict(required=False, default=None),
+        reuse=dict(required=False, type='bool', default=False),
+        fixed_address=dict(required=False, default=None),
+        wait=dict(required=False, type='bool', default=False),
+        timeout=dict(required=False, type='int', default=60),
+        internal_network=dict(required=False, default=None),
+    )
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    server_name_or_id = module.params['server']
+    state = module.params['state']
+    network = module.params['network']
+    floating_ip_address = module.params['floating_ip_address']
+    reuse = module.params['reuse']
+    fixed_address = module.params['fixed_address']
+    wait = module.params['wait']
+    timeout = module.params['timeout']
+    internal_network = module.params['internal_network']
+
+    cloud = shade.openstack_cloud(**module.params)
+
+    try:
+        server = cloud.get_server(server_name_or_id)
+        if server is None:
+            module.fail_json(
+                msg="server {0} not found".format(server_name_or_id))
+
+        if state == 'present':
+            # This part was added to support 'internal_network_name'
+            # as in Ansible 1.9.x. This entire file should be removed
+            # after this option added to Ansible 2.x
+            if internal_network:
+                internal_net_info = cloud.list_networks({'name':
+                                                         internal_network})
+                internal_network_id = internal_net_info[0]['id']
+                port_filter = {'device_id': server['id']}
+                port_filter['network_id'] = internal_network_id
+                ports = cloud.search_ports(filters=port_filter)
+                port = ports[0]
+                for address in port.get('fixed_ips', list()):
+                    try:
+                        ip = ipaddress.ip_address(address['ip_address'])
+                    except Exception:
+                        continue
+                    if ip.version == 4:
+                        fixed_address = address['ip_address']
+                        break
+
+            cloud.add_ips_to_server(
+                server=server, ips=floating_ip_address, reuse=reuse,
+                fixed_address=fixed_address, wait=wait, timeout=timeout)
+            fip_address = cloud.get_server_public_ip(server)
+            # Update the floating IP status
+            f_ip = _get_floating_ip(cloud, fip_address)
+            module.exit_json(changed=True, floating_ip=f_ip)
+
+        elif state == 'absent':
+            if floating_ip_address is None:
+                module.fail_json(msg="floating_ip_address is required")
+
+            f_ip = _get_floating_ip(cloud, floating_ip_address)
+
+            cloud.detach_ip_from_server(
+                server_id=server['id'], floating_ip_id=f_ip['id'])
+            # Update the floating IP status
+            f_ip = cloud.get_floating_ip(id=f_ip['id'])
+            module.exit_json(changed=True, floating_ip=f_ip)
+
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
+
+
+# this is magic, see lib/ansible/module_common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+
+
+if __name__ == '__main__':
+    main()

--- a/playbooks/provisioner/openstack/cleanup.yaml
+++ b/playbooks/provisioner/openstack/cleanup.yaml
@@ -1,0 +1,6 @@
+---
+- name: Cleanup OpenStack resources
+  hosts: localhost
+  roles:
+      - { role: openstack/nova, action: cleanup }
+      - { role: openstack/neutron, action: cleanup }

--- a/playbooks/provisioner/openstack/main.yaml
+++ b/playbooks/provisioner/openstack/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Provision OpenStack resources
+  hosts: localhost
+  roles:
+      - { role: openstack/neutron, action: setup }
+      - { role: openstack/nova, action: setup }

--- a/plugins/filters/add_prefix.py
+++ b/plugins/filters/add_prefix.py
@@ -1,0 +1,19 @@
+from ansible import utils
+
+
+def add_prefix(value, prefix=''):
+    """Add string prefix to item.
+
+    {{ ['hanukkah', 'easter', 'pessah'] | map('add_prefix', 'happy ' }}
+    -> ['happy hanukkah', 'happy easter', 'happy pessah']
+    """
+
+    return ''.join((prefix, value))
+
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            'add_prefix': add_prefix,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ansible>=2.0.0
 clg>=2.0.0
 configure>=0.5
 colorlog>=2.6.1
+python-novaclient<3
 PyYAML>=3.11
 shade>=1.7.0
 yamlordereddictloader>=0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 ansible>=2.0.0
-python-novaclient<3.0.0
-python-neutronclient>=4.0.0
-PyYAML>=3.11
+clg>=2.0.0
 configure>=0.5
 colorlog>=2.6.1
-clg>=2.0.0
+PyYAML>=3.11
+shade>=1.7.0
 yamlordereddictloader>=0.1.1

--- a/roles/openstack/neutron/defaults/main.yml
+++ b/roles/openstack/neutron/defaults/main.yml
@@ -16,3 +16,7 @@ dns_servers:
 # Router defaults
 
 router_name: router1
+
+# Security group defaults
+
+security_group_name: default

--- a/roles/openstack/neutron/defaults/main.yml
+++ b/roles/openstack/neutron/defaults/main.yml
@@ -1,0 +1,18 @@
+# General defaults
+
+prefix: "{{ provisioner.prefix | default(random.uuid) }}"
+
+# Network defaults
+
+timeout_network: 180
+
+# Subnet defaults
+
+enable_dhcp: True
+dns_servers:
+    - 208.67.222.222
+    - 8.8.8.8
+
+# Router defaults
+
+router_name: router1

--- a/roles/openstack/neutron/tasks/cleanup.yml
+++ b/roles/openstack/neutron/tasks/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# This file is used to cleanup OpenStack neutron resources
+
+- name: Cleanup routers
+  os_router:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      name: "{{ prefix }}{{ item.value.name | default(router_name) }}"
+      state: absent
+  with_dict: "{{ provisioner.neutron.routers }}"
+  when: provisioner.neutron.routers is defined
+  ignore_errors: yes
+
+- name: Cleanup subnets
+  os_subnet:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      state: absent
+  with_dict: "{{ provisioner.neutron.subnets }}"
+  when: provisioner.neutron.subnets is defined
+  ignore_errors: yes
+
+- name: Cleanup networks
+  os_network:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      state: absent
+  with_dict: "{{ provisioner.neutron.networks }}"
+  when: provisioner.neutron.networks is defined
+  ignore_errors: yes

--- a/roles/openstack/neutron/tasks/cleanup.yml
+++ b/roles/openstack/neutron/tasks/cleanup.yml
@@ -8,6 +8,7 @@
       state: absent
   with_dict: "{{ provisioner.neutron.routers }}"
   when: provisioner.neutron.routers is defined
+  register: routers
   ignore_errors: yes
 
 - name: Cleanup subnets
@@ -17,6 +18,7 @@
       state: absent
   with_dict: "{{ provisioner.neutron.subnets }}"
   when: provisioner.neutron.subnets is defined
+  register: subnets
   ignore_errors: yes
 
 - name: Cleanup networks
@@ -26,4 +28,19 @@
       state: absent
   with_dict: "{{ provisioner.neutron.networks }}"
   when: provisioner.neutron.networks is defined
+  register: networks
   ignore_errors: yes
+
+#TODO(abregman): Enable 'security groups' task when ansible 2.1 is out
+#- name: Cleanup security groups
+#  os_security_group:
+#      cloud: "{{ provisioner.cloud | default(omit) }}" 
+#      name: "{{ prefix }}{{ item.value.name | default(security_group_name) }}" 
+#      state: absent
+#  register: security_groups
+#  with_dict: "{{ provisioner.neutron.security_groups }}" 
+#  when: provisioner.neutron.security_groups is defined
+
+- name: Fail run if one of neutron cleanups tasks failed/skipped
+  fail: msg="The run failed because one of neutron cleanup tasks failed/skipped"
+  when: (routers|skipped or subnets|skipped or networks|skipped)

--- a/roles/openstack/neutron/tasks/main.yml
+++ b/roles/openstack/neutron/tasks/main.yml
@@ -1,0 +1,1 @@
+- include: "{{ action }}.yml"

--- a/roles/openstack/neutron/tasks/setup.yml
+++ b/roles/openstack/neutron/tasks/setup.yml
@@ -52,3 +52,26 @@
   register: routers
   with_dict: "{{ provisioner.neutron.routers }}"
   when: provisioner.neutron.routers is defined
+
+#TODO(abregman): Enable 'security groups' tasks when ansible 2.1 is out
+#- name: Create security groups
+#  os_security_group:
+#      cloud: "{{ provisioner.cloud | default(omit) }}"
+#      name: "{{ prefix }}{{ item.value.name | default(security_group_name) }}"
+#      state: present
+#  register: security_groups
+#  with_dict: "{{ provisioner.neutron.security_groups }}"
+#  when: provisioner.neutron.security_groups is defined
+
+#- name: Create security group rules
+#  os_security_group_rule:
+#      cloud: "{{ provisioner.cloud | default(omit) }}"
+#      security_group: "{{ prefix }}{{ item.value.name | default(security_group_name) }}"
+#      protocol: "{{ item.value.protocol | default(omit) }}"
+#      port_range_min: "{{ item.value.port_range_min | default(omit) }}"
+#      port_range_max: "{{ item.value.port_range_max | default(omit) }}"
+#      remote_ip_prefix: "{{ item.value.remote_ip_prefix | default(omit) }}"
+#      state: present
+#  register: security_group_rules
+#  with_dict: "{{ provisioner.neutron.security_groups.rules }}"
+#  when: provisioner.neutron.security_groups is defined

--- a/roles/openstack/neutron/tasks/setup.yml
+++ b/roles/openstack/neutron/tasks/setup.yml
@@ -1,0 +1,54 @@
+---
+# This file is used to create OpenStack neutron resources
+
+- name: Create networks
+  os_network:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      external: "{{ item.value.external | default(omit) }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      state: present
+      shared: "{{ item.value.shared | default(omit) }}"
+      timeout: "{{ item.value.timeout | default(timeout_network) }}"
+  register: networks
+  with_dict: "{{ provisioner.neutron.networks }}"
+  when: provisioner.neutron.networks is defined
+
+- name: Register externally accessible networks
+  os_networks_facts:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      filters:
+          router:external: true
+  register: networks_details
+- debug: var=networks_details
+
+- name: Set external network id
+  set_fact:
+      external_network_id: "{{ item.value[0].id }}"
+  with_dict: "{{ networks_details.ansible_facts }}"
+
+- name: Create subnets
+  os_subnet:
+      allocation_pool_start: "{{ item.value.allocation_pool_start }}"
+      allocation_pool_end: "{{ item.value.allocation_pool_end }}"
+      cidr: "{{ item.value.cidr | default(omit) }}"
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      dns_nameservers: "{{ item.value.dns_servers | default(dns_servers) }}"
+      enable_dhcp: "{{ item.value.enable_dhcp | default(enable_dhcp) }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      network_name: "{{ prefix }}{{ item.value.network_name }}"
+      state: present
+  register: subnets
+  with_dict: "{{ provisioner.neutron.subnets }}"
+  when: provisioner.neutron.subnets is defined
+
+- name: Create routers
+  os_router:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      external_fixed_ips: "{{ item.value.external_fixed_ips | default(omit) }}"
+      interfaces: "{{ item.value.attach_subnets | map('add_prefix', prefix) | join(',') }}"
+      name: "{{ prefix }}{{ item.value.name | default(router_name) }}"
+      network: "{{ external_network_id }}"
+      state: present
+  register: routers
+  with_dict: "{{ provisioner.neutron.routers }}"
+  when: provisioner.neutron.routers is defined

--- a/roles/openstack/nova/defaults/main.yml
+++ b/roles/openstack/nova/defaults/main.yml
@@ -1,0 +1,15 @@
+# General defaults
+
+prefix: "{{ provisioner.prefix | default(random.uuid) }}"
+
+# Instances defaults
+
+auto_ip: no
+config_drive: no
+instance_image: centos-minimal
+wait: yes
+
+# Flavor defaults
+
+flavor_id: 4
+flavor_name: ir-flavor

--- a/roles/openstack/nova/tasks/cleanup.yml
+++ b/roles/openstack/nova/tasks/cleanup.yml
@@ -1,0 +1,45 @@
+---
+# This file is used to cleanup OpenStack nova resources
+
+- name: Register nova servers details
+  os_server_facts:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      server: "{{ prefix }}*"
+  register: servers_details
+- debug: var=servers_details
+
+- name: Set floating IP address
+  set_fact:
+      floating_ip_address: "{{ item.value[0].interface_ip }}"
+  with_dict: servers_details.ansible_facts
+  ignore_errors: yes
+
+- name: Release floating IPs
+  os_floating_ip:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      server: "{{ prefix }}{{ item.value.name }}"
+      floating_ip_address: "{{ floating_ip_address }}"
+      state: absent
+  with_dict: "{{ provisioner.nodes }}"
+  when: provisioner.nodes is defined
+  ignore_errors: yes
+
+- name: Cleanup instances
+  os_server:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      image: "{{ item.value.image | default(instance_image) }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      state: absent
+  with_dict: "{{ provisioner.nodes }}"
+  when: provisioner.nodes is defined
+  ignore_errors: yes
+
+###todo(abregman): Enable 'Cleanup flavors' when ansible 2.1 is out
+#- name: Cleanup flavors
+#  os_nova_flavor:
+#      cloud: "{{ provisioner.cloud | default(omit) }}"
+#      name: "{{ prefix }}{{ item.value.nane | default(flavor_name) }}"
+#      state: absent
+#  with_dict: "{{ provisioner.flavors }}"
+#  when: provisioner.flavors is defined
+#  ignore_errors: yes

--- a/roles/openstack/nova/tasks/cleanup.yml
+++ b/roles/openstack/nova/tasks/cleanup.yml
@@ -1,40 +1,17 @@
 ---
 # This file is used to cleanup OpenStack nova resources
 
-- name: Register nova servers details
-  os_server_facts:
-      cloud: "{{ provisioner.cloud | default(omit) }}"
-      server: "{{ prefix }}*"
-  register: servers_details
-- debug: var=servers_details
+- include: "cleanup_nodes.yml"
+  with_dict: provisioner.nodes
 
-- name: Set floating IP address
-  set_fact:
-      floating_ip_address: "{{ item.value[0].interface_ip }}"
-  with_dict: servers_details.ansible_facts
-  ignore_errors: yes
-
-- name: Release floating IPs
-  os_floating_ip:
-      cloud: "{{ provisioner.cloud | default(omit) }}"
-      server: "{{ prefix }}{{ item.value.name }}"
-      floating_ip_address: "{{ floating_ip_address }}"
+- name: Remove keypair
+  os_keypair:
+      cloud: "{{ provisioner.cloud | default(omit) }}" 
+      name: "{{ prefix }}{{ provisioner.key.file | basename }}" 
       state: absent
-  with_dict: "{{ provisioner.nodes }}"
-  when: provisioner.nodes is defined
   ignore_errors: yes
 
-- name: Cleanup instances
-  os_server:
-      cloud: "{{ provisioner.cloud | default(omit) }}"
-      image: "{{ item.value.image | default(instance_image) }}"
-      name: "{{ prefix }}{{ item.value.name }}"
-      state: absent
-  with_dict: "{{ provisioner.nodes }}"
-  when: provisioner.nodes is defined
-  ignore_errors: yes
-
-###todo(abregman): Enable 'Cleanup flavors' when ansible 2.1 is out
+#TODO(abregman): Enable 'Cleanup flavors' when ansible 2.1 is out
 #- name: Cleanup flavors
 #  os_nova_flavor:
 #      cloud: "{{ provisioner.cloud | default(omit) }}"

--- a/roles/openstack/nova/tasks/cleanup_nodes.yml
+++ b/roles/openstack/nova/tasks/cleanup_nodes.yml
@@ -1,0 +1,22 @@
+---
+# This file includes tasks for instances and floating IPs cleanup.
+
+# Node type can be: controller, compute, ceph, etc.
+- name: Set fact for node type
+  set_fact:
+      node_type: "{{ item }}"
+
+# These tasks done for each type of node according to 'amount' variable
+- name: Cleanup instances
+  os_server:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      name: "{{ prefix }}{{ node_type.value.name }}-{{ item }}"
+      state: absent
+  with_sequence: "count={{ node_type.value.amount }}"
+  when: provisioner.nodes is defined
+  register: instances
+  ignore_errors: yes
+
+- name: Fail run if one of nova cleanups tasks failed/skipped
+  fail: msg="The run failed because one of nova cleanup tasks failed/skipped"
+  when: instances|skipped

--- a/roles/openstack/nova/tasks/main.yml
+++ b/roles/openstack/nova/tasks/main.yml
@@ -1,0 +1,1 @@
+- include: "{{ action }}.yml"

--- a/roles/openstack/nova/tasks/setup.yml
+++ b/roles/openstack/nova/tasks/setup.yml
@@ -1,0 +1,43 @@
+---
+# This file is used to create OpenStack nova resources
+
+#TODO(abregman): Enable 'create_flavors' when ansible 2.1 is out
+#- name: Create flavors
+#  os_nova_flavor:
+#      cloud: "{{ provisioner.cloud | default(omit) }}"
+#      name: "{{ prefix }}{{ item.value.nane | default(flavor_name) }}"
+#      ram: "{{ item.value.ram | default(omit) }}"
+#      disk: "{{ item.value.disk | default(omit) }}"
+#      vcpus: "{{ item.value.vcpus | default(omit) }}"
+#      state: present
+#  register: flavors
+#  with_dict: "{{ provisioner.flavors }}"
+#  when: provisioner.flavors is defined  
+
+- name: Create instances
+  os_server:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      auto_ip: "{{ item.value.auto_ip | default(auto_ip) }}"
+      config_drive: "{{ item.value.config_drive | default(config_drive) }}"
+      flavor: "{{ item.value.flavor | default(flavor_id) }}"
+      image: "{{ provisioner.image }}"
+      name: "{{ prefix }}{{ item.value.name }}"
+      nics: "{{ networks.results | map(attribute='id') | list() |map('add_prefix', 'net-id=') | list() }}"
+      key: "{{ item.value.key | default(omit) }}"
+      key_name: "{{ item.value.key_name | default(omit) }}"
+      state: present
+      wait: "{{ item.value.wait | default(wait) }}"
+  register: nodes
+  with_dict: "{{ provisioner.nodes }}"
+  when: provisioner.nodes is defined
+
+- name: Create floating IPs
+  os_floating_ip:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      network: "{{ external_network_id }}"
+      internal_network: "{{ prefix}}{{ item.value.network.floating_ip_network }}"
+      server: "{{ prefix }}{{ item.value.name }}"
+      state: present
+  register: floating_ips
+  with_dict: "{{ provisioner.nodes }}"
+  when: provisioner.nodes is defined

--- a/roles/openstack/nova/tasks/setup.yml
+++ b/roles/openstack/nova/tasks/setup.yml
@@ -14,30 +14,19 @@
 #  with_dict: "{{ provisioner.flavors }}"
 #  when: provisioner.flavors is defined  
 
-- name: Create instances
-  os_server:
-      cloud: "{{ provisioner.cloud | default(omit) }}"
-      auto_ip: "{{ item.value.auto_ip | default(auto_ip) }}"
-      config_drive: "{{ item.value.config_drive | default(config_drive) }}"
-      flavor: "{{ item.value.flavor | default(flavor_id) }}"
-      image: "{{ provisioner.image }}"
-      name: "{{ prefix }}{{ item.value.name }}"
-      nics: "{{ networks.results | map(attribute='id') | list() |map('add_prefix', 'net-id=') | list() }}"
-      key: "{{ item.value.key | default(omit) }}"
-      key_name: "{{ item.value.key_name | default(omit) }}"
-      state: present
-      wait: "{{ item.value.wait | default(wait) }}"
-  register: nodes
-  with_dict: "{{ provisioner.nodes }}"
-  when: provisioner.nodes is defined
+# This is needed for os_keypair as it uses public key
+- name: Retrieve public key from private key
+  shell: "ssh-keygen -y -f {{ provisioner.key.file }}"
+  register: public_key_content
 
-- name: Create floating IPs
-  os_floating_ip:
+- name: Add keypair
+  os_keypair:
       cloud: "{{ provisioner.cloud | default(omit) }}"
-      network: "{{ external_network_id }}"
-      internal_network: "{{ prefix}}{{ item.value.network.floating_ip_network }}"
-      server: "{{ prefix }}{{ item.value.name }}"
+      name: "{{ prefix }}{{ provisioner.key.file | basename }}"
+      public_key: "{{ public_key_content.stdout }}"
       state: present
-  register: floating_ips
+  when: not provisioner.key.name
+
+# This includes the tasks for instances and floating IPs creation
+- include: "setup_nodes.yml"
   with_dict: "{{ provisioner.nodes }}"
-  when: provisioner.nodes is defined

--- a/roles/openstack/nova/tasks/setup_nodes.yml
+++ b/roles/openstack/nova/tasks/setup_nodes.yml
@@ -1,0 +1,50 @@
+---
+# This file includes tasks for instances and floating IPs creation.
+
+# Node type can be: controller, compute, ceph, etc.
+- name: Set fact for node type
+  set_fact:
+      node_type: "{{ item }}"
+
+# These tasks done for each type of node according to 'amount' variable.
+- name: Create instances
+  os_server:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      auto_ip: "{{ node_type.value.auto_ip | default(auto_ip) }}"
+      config_drive: "{{ node_type.value.config_drive | default(config_drive) }}"
+      flavor: "{{ node_type.value.flavor | default(flavor_id) }}"
+      image: "{{ provisioner.image }}"
+      name: "{{ prefix }}{{ node_type.value.name }}-{{ item }}"
+      nics: "{{ networks.results | map(attribute='id') | list() |map('add_prefix', 'net-id=') | list() }}"
+      key_name: "{{ provisioner.key.name if provisioner.key.name else (prefix + provisioner.key.file | basename) }}"
+      state: present
+      wait: "{{ node_type.value.wait | default(wait) }}"
+  register: nodes
+  with_sequence: "count={{ node_type.value.amount }}"
+  when: provisioner.nodes is defined
+
+- name: Create floating IPs
+  os_floating_ip:
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+      network: "{{ external_network_id }}"
+      internal_network: "{{ prefix}}{{ node_type.value.network.floating_ip_network }}"
+      server: "{{ prefix }}{{ node_type.value.name }}-{{ item }}"
+      state: present
+  register: floating_ips
+  with_sequence: "count={{ node_type.value.amount }}"
+  when: provisioner.nodes is defined
+
+- name: Gather created servers facts
+  os_server_facts:
+      server: "{{ prefix }}{{ node_type.value.name }}*"
+      cloud: "{{ provisioner.cloud | default(omit) }}"
+  register: servers
+      
+- name: Add created servers to inventory
+  add_host:
+      name: "{{ prefix }}{{ node_type.value.name}}-{{item}}"
+      ansible_ssh_host: "{{ servers.ansible_facts.openstack_servers[0].public_v4 }}"
+      groups: "{{ provisioner.nodes[node_type.value.name].groups | join(',') }}"
+      ansible_ssh_private_key_file: "{{ provisioner.key.file }}"
+      ansible_ssh_user: 'cloud-user'
+  with_sequence: "count={{ node_type.value.amount }}"

--- a/settings/provisioner/openstack/neutron/default.yml
+++ b/settings/provisioner/openstack/neutron/default.yml
@@ -1,0 +1,37 @@
+---
+# This is the most common network topology for OpenStack Testing deployments
+
+networks:
+    data:
+        name: 'data'
+    external:
+        name: 'external'
+    management: 
+        name: 'management'
+
+subnets:
+    data:
+        name: "{{ !lookup provisioner.neutron.networks.data.name }}"
+        network_name: "{{ !lookup provisioner.neutron.networks.data.name }}"
+        allocation_pool_start: 172.16.1.10
+        allocation_pool_end: 172.16.1.100
+        cidr: 172.16.1.0/24
+    external:
+        name: "{{ !lookup provisioner.neutron.networks.external.name }}"
+        network_name: "{{ !lookup provisioner.neutron.networks.external.name }}"
+        allocation_pool_start: 172.31.0.10
+        allocation_pool_end: 172.31.0.100
+        cidr: 172.31.0.0/23
+    management:
+        name: "{{ !lookup provisioner.neutron.networks.management.name }}"
+        network_name: "{{ !lookup provisioner.neutron.networks.management.name }}"
+        allocation_pool_start: 192.168.1.10
+        allocation_pool_end: 192.168.1.100
+        cidr: 192.168.1.0/24
+
+routers:
+    router:
+        name: 'router'
+        attach_subnets:
+            - "{{ !lookup provisioner.neutron.networks.external.name }}"
+            - "{{ !lookup provisioner.neutron.networks.management.name }}"

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -14,6 +14,16 @@ subparsers:
                   prefix:
                       type: Value
                       help: An prefix which would be contacted to each provisioned resource. An random prefix would be generated in case this value is not specified.
+            - title: keypair details
+              options:
+                  key-file:
+                      type: Value
+                      help: The key file that would be uploaded to nova and injected into VMs upon creation.
+                      default: ~/.ssh/id_rsa
+                  key-name:
+                      type: Value
+                      help: The name of the key that would be uploaded to nova and injected into VMs upon creation. If this option is missing, a public key would be generated from the key file and uploaded as a key_pair to the cloud
+                      default: ''
             - title: image
               options:
                   image:

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -1,0 +1,60 @@
+---
+subparsers:
+    openstack:
+        help: Provision systems using Ansible OpenStack modules
+        groups:
+            - title: cloud
+              options:
+                  cloud:
+                      type: Value
+                      help: "The cloud which the OpenStack modules will operate against. Cloud setup instructions: http://docs.openstack.org/developer/os-client-config/#config-files"
+                      required: yes
+            - title: prefix
+              options:
+                  prefix:
+                      type: Value
+                      help: An prefix which would be contacted to each provisioned resource. An random prefix would be generated in case this value is not specified.
+            - title: image
+              options:
+                  image:
+                      type: Value
+                      help: An image id or name, on OpenStack cloud to provision the instance with. To see full list of images avaialable on the cloud, use 'glance image-list'.
+                      required: yes
+            - title: topology
+              options:
+                  neutron:
+                      type: YamlFile
+                      help: Network resources
+                      default: default.yml
+                  nodes:
+                      type: Topology
+                      help: Provision topology.
+                      default: "1_controller"
+            - title: common
+              options:
+                  dry-run:
+                      action: store_true
+                      help: Only generate settings, skip the playbook execution stage
+                  cleanup:
+                      action: store_true
+                      help: Clean given system instead of provisioning a new one
+                  input:
+                      action: append
+                      type: str
+                      short: i
+                      help: Input settings file to be loaded before the merging of user args
+                  output:
+                      type: str
+                      short: o
+                      help: 'File to dump the generated settings into (default: stdout)'
+                  extra-vars:
+                      action: append
+                      short: e
+                      help: Extra variables to be merged last
+                      type: str
+                  from-file:
+                      type: IniFile
+                      help: the ini file with the list of arguments
+                  generate-conf-file:
+                      type: str
+                      help: generate configuration file (ini) containing default values and exits. This file is than can be used with the from-file argument

--- a/settings/provisioner/openstack/openstack.yml
+++ b/settings/provisioner/openstack/openstack.yml
@@ -1,0 +1,14 @@
+---
+
+provisioner:
+    type: openstack
+
+job:
+  archive:
+  - /var/log/
+  - /etc/yum.repos.d
+  - /etc/selinux
+  - /root/
+
+random:
+    uuid: !random 6

--- a/settings/provisioner/topology/ceph.yaml
+++ b/settings/provisioner/topology/ceph.yaml
@@ -21,6 +21,8 @@ network:
             label: "eth1"
         external:
             label: "eth2"
+    floating_ip_network: management
+
 groups:
     - ceph
     - openstack_nodes

--- a/settings/provisioner/topology/compute.yaml
+++ b/settings/provisioner/topology/compute.yaml
@@ -18,6 +18,8 @@ network:
             label: "eth1"
         external:
             label: "eth2"
+    floating_ip_network: management
+
 groups:
     - compute
     - openstack_nodes

--- a/settings/provisioner/topology/controller.yaml
+++ b/settings/provisioner/topology/controller.yaml
@@ -18,6 +18,8 @@ network:
             label: "eth1"
         external:
             label: "eth2"
+    floating_ip_network: management
+
 groups:
     - controller
     - openstack_nodes

--- a/settings/provisioner/topology/undercloud.yaml
+++ b/settings/provisioner/topology/undercloud.yaml
@@ -18,6 +18,8 @@ network:
             label: "eth1"
         external:
             label: "eth2"
+    floating_ip_network: management
+
 groups:
   - undercloud
   - tester


### PR DESCRIPTION
Added OpenStack provisioner.

It is used for creating and/or removing resources on OpenStack clouds.

Includes:

* provision networks
    - Allows to specify if network is shared
    - Allows to specify timeout for network
* provisiom subnets
    - Allows to specify cidr, dns servers, allocation pool
      and whether DHCP should be enabled
* provision routers
    - Allows to attach network interfaces
    - Allows to specify default gateway
* provision instances
    - Allows to specify config_drive, nics, image and flavor
* provision flavors
    - Allows to specify ram, disk and vcpus
* provision floating IPs
    - Allows to reuse existing floating IPs
    - Allows to specify fixed IP address

The style is based on:
* 4 spaces
* module variables are sorted alphabetically
* blank line after each task