### PR TITLE
[RHOSINFRA-91] Add check for required arguments

### DIFF
--- a/cli/spec.py
+++ b/cli/spec.py
@@ -260,31 +260,26 @@ def override_default_values(clg_args, sub_parser_options):
             if isinstance(arg_obj, ValueArgument):
                 arg_obj.resolve_value(arg_name, defaults)
 
-        _check_required_arguments(clg_args)
+        _check_required_arguments(clg_args, sub_parser_options)
 
 
-def _check_required_arguments(clg_args):
+def _check_required_arguments(clg_args, sub_parser_options):
     """
     Verify all the required arguments are set.
 
     :param clg_args: Dictionary based on cmd-line args parsed by clg
+    :param sub_parser_options: Dictionary with all the options attributes for
+        a sub-command.
     """
-    # Only missing args initialize "required" attr in init_missing_args
-    unset_args = [arg.arg_name for arg in clg_args.values() if
-                  getattr(arg, 'required', False)]
-
-    # todo(yfried): revisit this in the future
-    # only_args = []
-    # for arg in clg_args.values():
-    #     if 'requires_only' in attributes:
-    #         only_args.extend(attributes['requires_only'])
-
-    # if only_args:
-    #     intersection = set(unset_args).intersection(set(only_args))
-    #     if intersection:
-    #         raise exceptions.IRConfigurationException(
-    #             "Missing mandatory arguments: {}".format(
-    #                 list(intersection)))
+    unset_args = []
+    for option, attributes in sub_parser_options.iteritems():
+        if attributes.get('required'):
+            # safely get the attribute provided value
+            value = clg_args.get(option, None)
+            if hasattr(value, 'value'):
+                value = value.value
+            if value is None:
+                unset_args.append(option)
     if unset_args:
         raise exceptions.IRConfigurationException(
             "Required input arguments {} are not set!".format(unset_args))

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -5,58 +5,30 @@ import pytest
 from cli import exceptions
 from cli import spec
 
-# todo(yfried): revisit this in the future
-# @pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
-#     # data set #1
-#     [{'host': None,
-#       'command0': 'virsh',
-#       'from-file': {
-#           'virsh': {
-#               'host': 'earth',
-#           }
-#       },
-#       'ssh-user': None},
-#      {
-#          'host': {'help': 'help', 'required': True},
-#          'ssh-user': {'help': 'help2', 'required': True},
-#          'ssh-key': {'help': 'help3', 'default': 'id_rsa'}
-#      }, ['ssh-user'], ['host', 'ssh-key']],
-#
-#     # data set #2
-#     [{'host': None,
-#       'command0': 'virsh',
-#       'ssh-user': None},
-#      {
-#          'host': {'help': 'help', 'required': True},
-#          'ssh-user': {'help': 'help2', 'required': True},
-#          'ssh-key': {'help': 'help3', 'default': 'id_rsa'}
-#      }, ['host', 'ssh-user'], ['ssh-key']],
-#
-#     # data set #3 (require_only)
-#     [{'host': None,
-#       'command0': 'virsh',
-#       'ssh-user': None,
-#       'req_only_opt': True},
-#      {
-#          'host': {'help': 'help', 'required': True},
-#          'ssh-user': {'help': 'help2', 'required': True},
-#          'ssh-key': {'help': 'help3', 'default': 'id_rsa'},
-#          'req_only_opt': {'requires_only': ['ssh-user']}
-#      }, ['ssh-user'], ['ssh-key', 'host']]
-# ])
-# def test_required_option_exception(res_args,
-#                                    options,
-#                                    req_args,
-#                                    nonreq_args):
-#
-#     with pytest.raises(exceptions.IRConfigurationException) as ex_info:
-#         spec.override_default_values(res_args, options)
-#
-#     for arg in req_args:
-#         assert arg in ex_info.value.message
-#
-#     for arg in nonreq_args:
-#         assert arg not in ex_info.value.message
+
+@pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
+    [{'host': spec.ValueArgument(),
+      'command0': 'virsh',
+      'ssh-user': spec.ValueArgument()},
+     {
+         'host': {'help': 'help', 'required': True},
+         'ssh-user': {'help': 'help2', 'required': True},
+         'ssh-key': {'help': 'help3', 'default': 'id_rsa'}
+     }, ['host', 'ssh-user'], ['ssh-key']],
+])
+def test_required_option_exception(res_args,
+                                   options,
+                                   req_args,
+                                   nonreq_args):
+
+    with pytest.raises(exceptions.IRConfigurationException) as ex_info:
+        spec.override_default_values(res_args, options)
+
+    for arg in req_args:
+        assert arg in ex_info.value.message
+
+    for arg in nonreq_args:
+        assert arg not in ex_info.value.message
 
 
 @pytest.mark.parametrize("res_args, options, expected_args", [


### PR DESCRIPTION
Added check that all the required arguments are set. 

We can check for that once all the arguments are loaded from cli, ini files and environment. So check was added to the end of parse_spec method. 

@yfried-redhat please review and let me know about any suggestions. 