### PR TITLE
[RHOSINFRA-98] Add support for NetApp storage backend

### DIFF
--- a/playbooks/installer/ospd/overcloud/run.yml
+++ b/playbooks/installer/ospd/overcloud/run.yml
@@ -18,8 +18,7 @@
             dest: "~/overcloud_deploy.sh"
             mode: 0755
   roles:
-      - {role: "ospd/overcloud/storage/ceph/", when: installer.overcloud.storage.backend == 'ceph'}
-      - {role: "ospd/overcloud/storage/netapp/", when: installer.overcloud.storage.backend == 'netapp'}
+      - {role: "ospd/overcloud/storage/{{ installer.overcloud.storage.backend }}/", when: installer.overcloud.storage.backend is defined}
       - {role: "ospd/overcloud/network/isolation/{{ installer.overcloud.network.isolation.type }}/", when: installer.overcloud.network.isolation.enable == "yes"}
       - {role: "ospd/overcloud/ssl/", when: installer.overcloud.use_ssl == "yes"}
 

--- a/playbooks/installer/ospd/overcloud/run.yml
+++ b/playbooks/installer/ospd/overcloud/run.yml
@@ -18,7 +18,7 @@
             dest: "~/overcloud_deploy.sh"
             mode: 0755
   roles:
-      - {role: "ospd/overcloud/storage/ceph/", when: provisioner.topology.nodes.ceph is defined or installer.overcloud.storage.external == "yes"}
+      - {role: "ospd/overcloud/storage/ceph/", when: installer.overcloud.storage.backend == 'ceph'}
       - {role: "ospd/overcloud/network/isolation/{{ installer.overcloud.network.isolation.type }}/", when: installer.overcloud.network.isolation.enable == "yes"}
       - {role: "ospd/overcloud/ssl/", when: installer.overcloud.use_ssl == "yes"}
 

--- a/playbooks/installer/ospd/overcloud/run.yml
+++ b/playbooks/installer/ospd/overcloud/run.yml
@@ -19,6 +19,7 @@
             mode: 0755
   roles:
       - {role: "ospd/overcloud/storage/ceph/", when: installer.overcloud.storage.backend == 'ceph'}
+      - {role: "ospd/overcloud/storage/netapp/", when: installer.overcloud.storage.backend == 'netapp'}
       - {role: "ospd/overcloud/network/isolation/{{ installer.overcloud.network.isolation.type }}/", when: installer.overcloud.network.isolation.enable == "yes"}
       - {role: "ospd/overcloud/ssl/", when: installer.overcloud.use_ssl == "yes"}
 

--- a/roles/ospd/overcloud/storage/netapp/tasks/main.yml
+++ b/roles/ospd/overcloud/storage/netapp/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare NetApp storage template
+  template:
+      src: "netapp.yml.j2"
+      dest: "{{ installer.overcloud.template_base }}/custom-netapp.yml"
+      mode: 0755
+
+- name: Append the storage NetApp custom template line to the base overcloud deploy script
+  lineinfile:
+      dest: "~/overcloud_deploy.sh"
+      line: '                       -e {{ installer.overcloud.template_base }}/custom-netapp.yml \\'

--- a/roles/ospd/overcloud/storage/netapp/templates/netapp.yml.j2
+++ b/roles/ospd/overcloud/storage/netapp/templates/netapp.yml.j2
@@ -1,0 +1,17 @@
+resource_registry:
+    OS::TripleO::ControllerExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/controller/cinder-netapp.yaml
+
+parameter_defaults:
+    CinderEnableNetappBackend: true
+    CinderEnableIscsiBackend: false
+    CinderNetappServerPort: '80'
+    CinderNetappSizeMultiplier: '1.2'
+    CinderNetappStorageFamily: 'ontap_7mode'
+    CinderNetappStorageProtocol: 'iscsi'
+    CinderNetappTransportType: 'http'
+    CinderNetappBackendName: 'tripleo_netapp'
+    CinderNetappLogin: 'automation'
+    CinderNetappVolumeList: 'vol_rhos_auto_iscsi'
+{% for key, val in installer.overcloud.storage.template.content.parameter_defaults.iteritems() %}
+    {{ key }}: '{{ val }}'
+{% endfor %}

--- a/roles/ospd/overcloud/storage/netapp/templates/netapp.yml.j2
+++ b/roles/ospd/overcloud/storage/netapp/templates/netapp.yml.j2
@@ -2,16 +2,25 @@ resource_registry:
     OS::TripleO::ControllerExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/controller/cinder-netapp.yaml
 
 parameter_defaults:
-    CinderEnableNetappBackend: true
     CinderEnableIscsiBackend: false
+    CinderEnableNetappBackend: true
     CinderNetappServerPort: '80'
     CinderNetappSizeMultiplier: '1.2'
     CinderNetappStorageFamily: 'ontap_7mode'
-    CinderNetappStorageProtocol: 'iscsi'
     CinderNetappTransportType: 'http'
-    CinderNetappBackendName: 'tripleo_netapp'
-    CinderNetappLogin: 'automation'
-    CinderNetappVolumeList: 'vol_rhos_auto_iscsi'
+
+{%  if installer.overcloud.storage.protocol == 'iscsi' %}
+    CinderNetappBackendName: 'tripleo_netapp_iscsi'
+    CinderNetappStorageProtocol: 'iscsi'
+{%  elif installer.overcloud.storage.protocol == 'nfs' %}
+    CinderNetappBackendName: 'tripleo_netapp_nfs'
+    CinderNetappStorageProtocol: 'nfs'
+    CinderNetappVfiler: ''
+    CinderNetappVserver: ''
+    CinderNetappPartnerBackendName: ''
+    CinderNetappNfsSharesConfig: '/etc/cinder/shares.conf'
+{% endif %}
+
 {% for key, val in installer.overcloud.storage.template.content.parameter_defaults.iteritems() %}
     {{ key }}: '{{ val }}'
 {% endfor %}

--- a/settings/installer/ospd/storage/ceph.yml
+++ b/settings/installer/ospd/storage/ceph.yml
@@ -3,6 +3,7 @@
 installer:
     overcloud:
         storage:
+            backend: "ceph"
             external: "no"
             template:
                 content:

--- a/settings/installer/ospd/storage/netapp.yml
+++ b/settings/installer/ospd/storage/netapp.yml
@@ -8,3 +8,7 @@ installer:
                     parameter_defaults:
                         CinderNetappPassword: "{{ !lookup private.storage.netapp.CinderNetappPassword }}"
                         CinderNetappServerHostname: "{{ !lookup private.storage.netapp.CinderNetappServerHostname  }}"
+                        CinderNetappLogin: "{{ !lookup private.storage.netapp.CinderNetappLogin }}"
+
+defaults:
+    protocol: iscsi

--- a/settings/installer/ospd/storage/netapp.yml
+++ b/settings/installer/ospd/storage/netapp.yml
@@ -1,0 +1,10 @@
+---
+installer:
+    overcloud:
+        storage:
+            backend: "netapp"
+            template:
+                content:
+                    parameter_defaults:
+                        CinderNetappPassword: "{{ !lookup private.storage.netapp.CinderNetappPassword }}"
+                        CinderNetappServerHostname: "{{ !lookup private.storage.netapp.CinderNetappServerHostname  }}"

--- a/settings/installer/ospd/storage/netapp/protocol/iscsi.yml
+++ b/settings/installer/ospd/storage/netapp/protocol/iscsi.yml
@@ -1,0 +1,9 @@
+---
+installer:
+    overcloud:
+        storage:
+            protocol: "iscsi"
+            template:
+                content:
+                    parameter_defaults:
+                        CinderNetappVolumeList: "{{ !lookup private.storage.netapp.CinderNetappVolumeList }}"

--- a/settings/installer/ospd/storage/netapp/protocol/nfs.yml
+++ b/settings/installer/ospd/storage/netapp/protocol/nfs.yml
@@ -1,0 +1,10 @@
+---
+installer:
+    overcloud:
+        storage:
+            protocol: "nfs"
+            template:
+                content:
+                    parameter_defaults:
+                        CinderNetappNfsShares: "{{ !lookup private.storage.netapp.CinderNetappNfsShares }}"
+                        CinderNetappNfsMountOptions: "{{ !lookup private.storage.netapp.CinderNetappNfsMountOptions }}"


### PR DESCRIPTION
Yogev Rabl confirmed that the iscsi protocol works fine with a workaround and that the nfs doesn't work atm - he's working to find the reason for that
(https://bugzilla.redhat.com/show_bug.cgi?id=1321453)

Per @tkammer request, it is possible to review this PR and merged it if it passed the review and the gate, in order to create 2 jobs for the NetApp backend, one for iscsi and one for nfs.

Resolves RHOSINFRA-93
Resolves RHOSINFRA-97