### PR TITLE
Add shade to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 ansible>=2.0.0
-python-novaclient<3.0.0
-python-neutronclient>=4.0.0
-PyYAML>=3.11
-configure>=0.5
-colorlog>=2.6.1
 clg>=2.0.0
+colorlog>=2.6.1
+configure>=0.5
+python-neutronclient>=4.0.0
+python-novaclient<3.0.0
+PyYAML>=3.11
+shade
 yamlordereddictloader>=0.1.1


### PR DESCRIPTION
Shade is used by OpenStack modules.