### PR TITLE
[RHOSINFRA-96] Fix 'choices' issue in spec parser

### DIFF
--- a/cli/spec.py
+++ b/cli/spec.py
@@ -1,4 +1,5 @@
 import ConfigParser
+from functools import total_ordering
 
 import clg
 import os
@@ -19,6 +20,7 @@ BUILTINS_REPLACEMENT = {
 TRIM_PARAMS = ['default', 'required']
 
 
+@total_ordering
 class ValueArgument(object):
     """
     Default argument type for InfraRed Spec
@@ -107,6 +109,27 @@ class ValueArgument(object):
         # override get default from conf file
         if self.value is None:
             self.value = defaults.get(self.arg_name)
+
+    def __eq__(self, other):
+        """
+        Checks if other value is equal to the current value.
+        """
+        if isinstance(other, ValueArgument):
+            return self.value == other.value
+        else:
+            return self.value == other
+
+    def __lt__(self, other):
+        """
+        Checks if current value is less than other value.
+        """
+        if isinstance(other, ValueArgument):
+            return self.value < other.value
+        else:
+            return self.value < other
+
+    def __repr__(self):
+        return self.value
 
 
 class YamlFileArgument(ValueArgument):

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -105,7 +105,8 @@ def search_tree(needle, haystack, _res=None):
             search_tree(needle, value, _res)
         if isinstance(value, list):
             for item in value:
-                search_tree(needle, item, _res)
+                if isinstance(item, dict):
+                    search_tree(needle, item, _res)
     return _res
 
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from cli import exceptions
 from cli import spec
+from cli.spec import ValueArgument
 
 
 @pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
@@ -86,3 +87,19 @@ def test_required_options_are_set(res_args,
                                   expected_args):
     actual_args = spec.override_default_values(res_args, options)
     cmp(actual_args, expected_args)
+
+
+@pytest.mark.parametrize('test_value', [
+  'test string', 1, 0.1
+])
+def test_value_argument_compare(test_value):
+    val = ValueArgument(test_value)
+
+    # verify several equality checks
+    assert val == test_value
+    assert val in [test_value, ]
+
+    # negative case
+    val = ValueArgument(0)
+    assert val != test_value
+    assert val not in [test_value, ]


### PR DESCRIPTION
Now we can use choices for Value arguments. 

@yfried-redhat @aopincar, please review. 