### PR TITLE
Add the option to run smoke tests only on tempest

### DIFF
--- a/settings/tester/tempest/tests/smoke.yml
+++ b/settings/tester/tempest/tests/smoke.yml
@@ -1,0 +1,5 @@
+tester:
+    tempest:
+        test_regex: .*smoke*
+        whitelist: []
+        blacklist: []


### PR DESCRIPTION
This add the option to run smoke tests with --tempest-tests=smoke