### PR TITLE
Adding sanity option to tempest-tests

### DIFF
--- a/settings/tester/tempest/tests/sanity.yml
+++ b/settings/tester/tempest/tests/sanity.yml
@@ -1,0 +1,8 @@
+tester:
+    tempest:
+        test_regex: ''
+        whitelist:
+          - tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
+          - tempest.scenario.test_minimum_basic.TestMinimumBasicScenario
+          - tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+        blacklist: []


### PR DESCRIPTION
This is a temporary solution to nightly jobs who doesn't need to ran the whole
tempest, only a basic set of jobs to ensure that the basic tests were passing.