### PR TITLE
Virtualenv support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,22 @@ Setup
 
   $ dnf install redhat-rpm-config
 
+Virtualenv
+----------
+
+InfraRed shares many dependencies with other OpenStack products and projects. Therefore there's a high probability of
+conflicts with python dependencies, which would result either with InfraRed failure, or worse, with breaking dependencies
+for other OpenStack products.
+When working from source, it is recommended to use python `virutalenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_
+to avoid corrupting the system packages::
+
+  $ virtualenv --system-site-packages .venv
+  $ source .venv/bin/activate
+
+.. note:: Create virtualenv with site packages enabled because Ansible file modules require python-libselinux binding.
+ However, according to `this blog post <https://dmsimard.com/2016/01/08/selinux-python-virtualenv-chroot-and-ansible-dont-play-nice/>`_
+ libselinux-python can be hacked into regular virtualenvs as well.
+
 Use pip to install from source::
 
   $ pip install <path_to_infrared_dir>

--- a/local_hosts
+++ b/local_hosts
@@ -1,2 +1,2 @@
 [local]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=python

--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -4,10 +4,8 @@
 - name: restore inventory file with just localhost
   hosts: localhost
   tasks:
-    - file:
+    - name: Unlink hosts file
+      file:
         dest: "{{ lookup('env', 'PWD') }}/hosts"
         state: link
         src: "{{ lookup('env', 'PWD') }}/local_hosts"
-    - file:
-        dest: "{{ lookup('env', 'PWD') }}/hosts-{{ lookup('env', 'USER') }}"
-        state: absent

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -1,10 +1,16 @@
 {% for host in groups['all'] %}
 {% if hostvars[host].get('ansible_connection', '') == 'local' %}
-{{ host }} ansible_connection=local
+{{ host }} ansible_connection=local ansible_python_interpreter=python
 {% elif hostvars[host]['ansible_ssh_private_key_file'] is defined %}
 {{ host }} ansible_ssh_host={{ hostvars[host]['ansible_ssh_host'] }} ansible_ssh_user={{ hostvars[host]['ansible_ssh_user'] }} ansible_ssh_private_key_file={{ hostvars[host]['ansible_ssh_private_key_file'] }}
+{%- if hostvars[inventory_hostname]['ansible_python_interpreter'] is defined %}
+ ansible_python_interpreter={{ hostvars[inventory_hostname]['ansible_python_interpreter'] }}
+{% endif %}
 {% else %}
 {{ host }} ansible_ssh_host={{ hostvars[host]['ansible_ssh_host'] }} ansible_ssh_user={{ hostvars[host]['ansible_ssh_user'] }} ansible_ssh_password={{ hostvars[host]['ansible_ssh_password'] }}
+{%- if hostvars[inventory_hostname]['ansible_python_interpreter'] is defined %}
+ ansible_python_interpreter={{ hostvars[inventory_hostname]['ansible_python_interpreter'] }}
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Use default python interpreter on localhost.

Ansible will use the system python interpreter by default, but on
localhost, user might be using virtualenv.
Write this to inventory files as well.