### PR TITLE
[RHOSINFRA-134] Print available yaml files to the help message

### DIFF
--- a/cli/spec.py
+++ b/cli/spec.py
@@ -14,11 +14,6 @@ from cli import utils
 LOG = logger.LOG
 
 SPEC_EXTENSION = '.spec'
-BUILTINS_REPLACEMENT = {
-    '__DEFAULT__': "default"
-}
-
-TRIM_PARAMS = ['default', 'required']
 
 
 @total_ordering
@@ -149,19 +144,64 @@ class YamlFileArgument(ValueArgument):
 
     """
 
+    @classmethod
+    def get_file_locations(cls, settings_dir, subcommand, arg_name):
+        """
+        Get the possible locations (folders) where the
+        yaml files can be stored.
+
+        :param settings_dir: path to the base directory holding the
+            application's settings. App can be provisioner\installer\tester
+            and the path would be: settings/<app_name>/
+        :param subcommand: the subcommand name (e.g. virsh, ospd, etc)
+        :param arg_name: the argument name
+        :return The list of folders to search for the yaml files.
+        """
+        search_first = os.path.join(settings_dir,
+                                    subcommand,
+                                    *arg_name.split("-"))
+        search_second = os.path.join(settings_dir,
+                                     *arg_name.split("-"))
+        return search_first, search_second, "."
+
+    @classmethod
+    def get_allowed_files(cls, settings_dir, subcommand, arg_name,
+                          search_root=False):
+        """
+        Gets the list of the the files in the default locations.
+
+        :param settings_dir: path to the base directory holding the
+            application's settings. App can be provisioner\installer\tester
+            and the path would be: settings/<app_name>/
+        :param subcommand: the subcommand name (e.g. virsh, ospd, etc)
+        :param arg_name: the argument name
+        :param search_root: specify whether the execution root folder
+            should be searched for yamk files. By default equals
+            to False to avoid unnecessary files.
+        """
+
+        res = []
+        locations = cls.get_file_locations(settings_dir,
+                                           subcommand,
+                                           arg_name)
+        if search_root is False:
+            locations = locations[:-1]
+        for folder in locations:
+            res.extend(glob.glob(folder + "/*.*"))
+
+        return res
+
     def resolve_value(self, arg_name, defaults=None):
         super(YamlFileArgument, self).resolve_value(arg_name, defaults)
 
-        search_first = os.path.join(self.get_app_attr("settings_dir"),
-                                    self.get_app_attr("subcommand"),
-                                    *arg_name.split("-"))
-        search_second = os.path.join(self.get_app_attr("settings_dir"),
-                                     *arg_name.split("-"))
+        search_paths = self.get_file_locations(
+            self.get_app_attr("settings_dir"),
+            self.get_app_attr("subcommand"),
+            arg_name)
 
         if self.value is not None:
             self.value = utils.load_yaml(self.value,
-                                         search_first,
-                                         search_second)
+                                         *search_paths)
         else:
             pass
 
@@ -227,6 +267,124 @@ class IniFileArgument(object):
         self.value = res_dict
 
 
+class ArgumentsPreProcessor(object):
+    """
+    The helper class which is responsible to to transform input cli arguments
+    prior passing them to the clg module for parsing.
+    """
+    BUILTINS_REPLACEMENT = {
+        '__DEFAULT__': "default"
+    }
+
+    TRIM_PARAMS = ['default', 'required']
+
+    def __init__(self, settings_dir, app_settings_dir):
+        self.app_settings_dir = app_settings_dir
+        self.settings_dir = settings_dir
+
+    def process(self, spec_dict):
+        """
+        Goes through all the spec options and modifies them by removing some
+        options parameters (like defaults) and adding additional help info.
+
+        :param spec_dict: the dictionary with key obtained from spec files
+        :return the list of
+        """
+        # Collect sub parsers options
+        options = {}
+        for sub_parser, params in spec_dict.get('subparsers', {}).iteritems():
+            parser_options = self._process_options(params, sub_parser)
+
+            # go over the groups if present
+            group_options = {}
+            for group in params.get('groups', {}):
+                group_options.update(self._process_options(group, sub_parser))
+
+            utils.dict_merge(parser_options, group_options)
+            options[sub_parser] = parser_options
+
+        return options
+
+    def _process_options(self, spec_dict, subcommand):
+        """
+        Gets the dict of options listed in the spec of group.
+
+        This method will also remove some methods and will replace
+         __<value>__ pattens in the option properties
+         (e.g. __default__, __FILE__)
+
+        :param spec_dict: the dictionary to look for new options.
+        :param sub_parser: the subcommand name.
+        """
+        options_dict = {}
+        for option, attributes in spec_dict.get('options', {}).iteritems():
+            self._add_default_to_option_help(attributes)
+            self._add_yaml_info(option, attributes, subcommand)
+            self._replace_builtin(attributes)
+
+            # Get a parameters copy with all the keys.
+            options_dict[option] = dict(attributes)
+
+            self._trim_option(attributes)
+
+        return options_dict
+
+    def _add_yaml_info(self, option_name, option_attributes, subcommand):
+        """
+        Adds the list of available yaml files to the help message.
+        :param option_name: the option name (key)
+        :param option_attributes: dictionary with option attributes (help,
+        type, default, etc)
+        :param subcommand: the subcommand name
+        """
+        if option_attributes.get(
+                'type', None) == 'YamlFile' and subcommand is not None:
+            allowed_files = YamlFileArgument.get_allowed_files(
+                self.app_settings_dir, subcommand, option_name)
+
+            option_attributes['help'] += ". Available files: {{{0}}}".format(
+                ", ".join(map(os.path.basename, allowed_files))
+            )
+
+    def _add_default_to_option_help(self, option_attributes):
+        """
+        Update the help by inserting default values if required.
+
+        :param option_attributes: dictionary with option attributes (help,
+        type, default, etc)
+        """
+        # Insert default value into help.
+        if all(attr in option_attributes for attr in ('help', 'default')) \
+                and '__DEFAULT__' not in option_attributes['help']:
+            option_attributes['help'] += " (default: {})".format(
+                option_attributes['default'])
+
+    def _replace_builtin(self, option_attributes):
+        """
+        Modifies existing option parameters by replacing __*__ patterns
+
+        :param option_attributes: dictionary with option attributes (help,
+        type, default, etc)
+        """
+        # check __*__ pattern
+        for attr_key, attr_value in option_attributes.iteritems():
+            for builtin, replacement in self.BUILTINS_REPLACEMENT.iteritems():
+                if builtin in str(attr_value):
+                    option_attributes[attr_key] = \
+                        attr_value.replace(builtin, str(
+                            option_attributes.get(replacement, builtin)))
+
+    def _trim_option(self, option_attributes):
+        """
+        Removes the defined option parameters.
+
+        :param option_attributes: dictionary with option attributes (help,
+        type, default, etc)
+        """
+        for trim_param in self.TRIM_PARAMS:
+            option_attributes.pop(trim_param, None)
+
+
 def parse_args(settings_dir, app_settings_dir, args=None):
     """
     Looks for all the specs for specified app
@@ -248,7 +406,8 @@ def parse_args(settings_dir, app_settings_dir, args=None):
 
     # Get the subparsers options as is with all the fields from app's specs.
     # This also trims some custom fields from options to pass to clg.
-    subparsers_options = _get_subparsers_options(app_specs)
+    subparsers_options = ArgumentsPreProcessor(
+        settings_dir, app_settings_dir).process(app_specs)
 
     # Pass trimmed spec to clg with modified help message
     cmd = clg.CommandLine(app_specs)
@@ -346,101 +505,6 @@ def _generate_config_file(file_name, subcommand, defaults):
             out_config.write(configfile)
     except Exception as ex:
         raise exceptions.IRException(ex.message)
-
-
-def _get_subparsers_options(spec_dict):
-    """
-    Goes through all the spec options and modifies them by removing some
-    options parameters (like defaults)
-
-    :param spec_dict: the dictionary with key obtained from spec files
-    """
-    # Collect sub parsers options
-    options = {}
-    for sub_parser, params in spec_dict.get('subparsers', {}).iteritems():
-        parser_options = _get_parser_options(params)
-        group_options = _get_parser_group_options(params)
-
-        utils.dict_merge(parser_options, group_options)
-        options[sub_parser] = parser_options
-
-    return options
-
-
-def _get_parser_group_options(spec_dict):
-    """
-    Gets the dict of options nested within the spec groups
-
-    :param spec_dict: the dictionary to look for new group options.
-    """
-    options = {}
-    for group in spec_dict.get('groups', {}):
-        options.update(_get_parser_options(group))
-
-    return options
-
-
-def _get_parser_options(spec_dict):
-    """
-    Gets the dict of options listed in the spec of group.
-
-    This method will also remove some methods and will replace
-     __<value>__ pattens in the option properties (e.g. __default__, __FILE__)
-
-    :param spec_dict: the dictionary to look for new options.
-    """
-    options_dict = {}
-    for option, attributes in spec_dict.get('options', {}).iteritems():
-        _add_default_to_option_help(attributes)
-        _replace_builtin(attributes)
-
-        # Get a parameters copy with all the keys.
-        options_dict[option] = dict(attributes)
-
-        _trim_option(attributes)
-
-    return options_dict
-
-
-def _add_default_to_option_help(option_attributes):
-    """
-    Update the help by inserting default values if required.
-
-    :param option_attributes: dictionary with option attributes (help, type,
-    default, etc)
-    """
-    # Insert default value into help.
-    if all(attr in option_attributes for attr in ('help', 'default')) \
-            and '__DEFAULT__' not in option_attributes['help']:
-        option_attributes['help'] += " (default: {})".format(
-            option_attributes['default'])
-
-
-def _replace_builtin(option_attributes):
-    """
-    Modifies existing option parameters by replacing __*__ patterns
-
-    :param option_attributes: dictionary with option attributes (help, type,
-    default, etc)
-    """
-    # check __*__ pattern
-    for attr_key, attr_value in option_attributes.iteritems():
-        for builtin, replacement in BUILTINS_REPLACEMENT.iteritems():
-            if builtin in str(attr_value):
-                option_attributes[attr_key] = \
-                    attr_value.replace(builtin, str(
-                        option_attributes.get(replacement, builtin)))
-
-
-def _trim_option(option_attributes):
-    """
-    Removes the defined option parameters.
-
-    :param option_attributes: dictionary with option attributes (help, type,
-    default, etc)
-    """
-    for trim_param in TRIM_PARAMS:
-        option_attributes.pop(trim_param, None)
 
 
 def _get_specs(root_folder, include_subfolders=True):

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -187,15 +187,13 @@ def load_yaml(filename, *search_paths):
     """Find YAML file. search default path first.
 
     :param filename: path to file
-    :param search_first: default path to search first
+    :param search_paths: the list of paths to search for a file.
     :returns: dict. loaded YAML file.
     """
     path = None
     searched_files = []
     files_to_search = map(
         lambda search_path: os.path.join(search_path, filename), search_paths)
-    # append file name to verify absolute path by default
-    files_to_search.append(filename)
 
     for filename in files_to_search:
         searched_files.append(os.path.abspath(filename))

--- a/settings/installer/ospd/ospd.spec
+++ b/settings/installer/ospd/ospd.spec
@@ -1,6 +1,7 @@
 ---
 subparsers:
     ospd:
+        formatter_class: RawTextHelpFormatter
         help: Installs openstack using OSP Director
         groups:
             - title: Firewall

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -1,6 +1,7 @@
 ---
 subparsers:
     openstack:
+        formatter_class: RawTextHelpFormatter
         help: Provision systems using Ansible OpenStack modules
         groups:
             - title: cloud

--- a/settings/provisioner/virsh/virsh.spec
+++ b/settings/provisioner/virsh/virsh.spec
@@ -1,6 +1,7 @@
 ---
 subparsers:
     virsh:
+        formatter_class: RawTextHelpFormatter
         help: Provision systems using virsh
         groups:
             - title: Hypervisor

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from cli import exceptions
 from cli import spec
-from cli.spec import ValueArgument
+from cli.spec import ValueArgument, YamlFileArgument
 
 
 @pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
@@ -103,3 +103,39 @@ def test_value_argument_compare(test_value):
     val = ValueArgument(0)
     assert val != test_value
     assert val not in [test_value, ]
+
+
+def test_yamls_file_locations(tmpdir):
+    """
+    Verify IR is looking for correct file locations.
+    """
+    subcommand = "virsh"
+
+    # create mock settings structure
+    app_dir = tmpdir.mkdir("installer")
+    app_spec_dir = app_dir.mkdir(subcommand)
+    file1 = app_dir.mkdir("arg1").mkdir("arg2").join("test_load2.yml")
+    file2 = app_spec_dir.mkdir("arg1").mkdir("arg2").join("test_load1.yml")
+    file1.write("""---
+    network:
+        ip: 1
+    """)
+    file2.write("""---
+    network:
+        ip: 2
+    """)
+
+    locations = YamlFileArgument.get_file_locations(
+        app_dir.strpath, subcommand, "arg1-arg2")
+
+    assert len(locations) == 3
+    assert locations[0] == file2.dirname
+    assert locations[1] == file1.dirname
+    assert locations[2] == "."
+
+    files = YamlFileArgument.get_allowed_files(
+        app_dir.strpath, subcommand, "arg1-arg2")
+
+    assert len(files) == 2
+    assert files[0] == file2.strpath
+    assert files[1] == file1.strpath


### PR DESCRIPTION
Print all the available options for YamlFile arguments into the help message. 

@yfried-redhat @tkammer please review. 

Help output example: 
```

Undercloud:
  --undercloud-config UNDERCLOUD-CONFIG
                        The undercloud config details
                        Default value: default.yml
                        Available files: { default.yml }

Overcloud:
  --overcloud-ssl OVERCLOUD-SSL
                        Specifies whether ths SSL should be used for overcloud
                        Default value: no

Overcloud storage:
  --storage STORAGE     The overcloud storage type
                        Default value: ceph.yml
                        Available files: { ceph.yml, netapp-iscsi.yml, netapp-nfs.yml, ceph-external.yml }


```
