### PR TITLE
Updating testtools dependences to match tempest upstream

### DIFF
--- a/settings/tester/tempest/setup/git.yml
+++ b/settings/tester/tempest/setup/git.yml
@@ -17,4 +17,3 @@ tester:
         - junitxml
         - unittest2
         - nose
-        - testtools==1.4 # Tempest needs at least 1.4.0 (assertIn problem)

--- a/settings/tester/tempest/setup/git.yml
+++ b/settings/tester/tempest/setup/git.yml
@@ -17,4 +17,4 @@ tester:
         - junitxml
         - unittest2
         - nose
-        - testtools==0.9.36 # Tempest needs at least 0.9.36 (assertIn problem)
+        - testtools==1.4 # Tempest needs at least 1.4.0 (assertIn problem)


### PR DESCRIPTION
Tempest upstream requires testtools>= 1.4.0 while we were still using
testtools 0.9. This makes some tests fails in assertRaisesRegex since
testtools 0.9 doesn't have this method, only the assertRaisesRegexp that
were deprecated.