### PR TITLE
[RHOSINFRA-144] Ux improvements for confgi file and defaults values

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -188,7 +188,7 @@ def load_yaml(filename, *search_paths):
             break
 
     if path is not None:
-        print("Loading YAML file: %s" % path)
+        LOG.debug("Loading YAML file: %s" % path)
         return cli.yamls.load(path)
     else:
         raise exceptions.IRFileNotFoundException(

--- a/settings/provisioner/virsh/virsh.spec
+++ b/settings/provisioner/virsh/virsh.spec
@@ -33,7 +33,7 @@ subparsers:
                   topology-nodes:
                       type: Topology
                       help: Provision topology.
-                      default: "1_controller,1_compute,1_undercloud"
+                      default: "1_undercloud,1_controller,1_compute"
             - title: common
               options:
                   dry-run:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -8,6 +8,7 @@ from cli.spec import ValueArgument, YamlFileArgument
 
 default_settings_dir = "."
 
+
 @pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
     [{'host': spec.ValueArgument(),
       'command0': 'virsh',

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -6,6 +6,7 @@ from cli import exceptions
 from cli import spec
 from cli.spec import ValueArgument, YamlFileArgument
 
+default_settings_dir = "."
 
 @pytest.mark.parametrize("res_args, options, req_args, nonreq_args", [
     [{'host': spec.ValueArgument(),
@@ -23,7 +24,7 @@ def test_required_option_exception(res_args,
                                    nonreq_args):
 
     with pytest.raises(exceptions.IRConfigurationException) as ex_info:
-        spec.override_default_values(res_args, options)
+        spec.override_default_values(default_settings_dir, res_args, options)
 
     for arg in req_args:
         assert arg in ex_info.value.message
@@ -85,7 +86,8 @@ def test_required_option_exception(res_args,
 def test_required_options_are_set(res_args,
                                   options,
                                   expected_args):
-    actual_args = spec.override_default_values(res_args, options)
+    actual_args = spec.override_default_values(
+        default_settings_dir, res_args, options)
     cmp(actual_args, expected_args)
 
 


### PR DESCRIPTION
Display warnings when we use defaults values from spec file. 

Examples: 

```
(venv)➜  InfraRed git:(RHOSINFRA-144-part2) ✗ ir-installer ospd
WARNING Argument 'network-backend' was not supplied. Using: 'vxlan' as default.
WARNING Argument 'firewall' was not supplied. Using: 'default.yml' as default.
WARNING Argument 'product-build' was not supplied. Using: 'latest' as default.
WARNING Argument 'undercloud-config' was not supplied. Using: 'default.yml' as default.
WARNING Argument 'user-password' was not supplied. Using: 'stack' as default.
WARNING Argument 'user-name' was not supplied. Using: 'stack' as default.
WARNING Argument 'network-protocol' was not supplied. Using: 'ipv4' as default.
WARNING Argument 'overcloud-ssl' was not supplied. Using: 'no' as default.
WARNING Argument 'storage' was not supplied. Using: 'no-storage.yml' as default.
WARNING Argument 'product-core-build' was not supplied. Using: 'latest' as default.
ERROR   Required input arguments ['product-core-version', 'images-task', 'network-isolation', 'product-version'] are not set!
```

```
(venv)➜  InfraRed git:(RHOSINFRA-144-part2) ✗ ir-provisioner virsh
WARNING Argument 'host-key' was not supplied. Using: '~/.ssh/id_rsa' as default.
WARNING Argument 'host-user' was not supplied. Using: 'root' as default.
WARNING Argument 'topology-nodes' was not supplied. Using: '1_controller,1_compute,1_undercloud' as default.
WARNING Argument 'topology-network' was not supplied. Using: 'default.yml' as default.
ERROR   Required input arguments ['image', 'host-address'] are not set!
```

```
(venv)➜  InfraRed git:(RHOSINFRA-144-part2) ✗ ir-provisioner virsh --generate-conf-file=test.ini
WARNING Required argument 'image' not supplied. Please edit config file with one of ['rhel-7.2.yml.1', 'rhel-7.2.yml', 'sample.yml.example'] options, OR override through CLI: --image=<option>. 
WARNING Required argument 'host-address' not supplied. Please edit config file with any value, OR override through CLI: --host-address=<option>. 

(venv)➜  InfraRed git:(RHOSINFRA-144-part2) ✗ cat test.ini
[virsh]
topology-nodes = 1_controller,1_compute,1_undercloud
topology-network = default.yml
host-key = ~/.ssh/id_rsa
host-user = root
image = Edit with one of ['rhel-7.2.yml.1', 'rhel-7.2.yml', 'sample.yml.example'] options, OR override with CLI: --image=<option>
host-address = Edit with any value, OR override with CLI: --host-address=<option>


```