### PR TITLE
Change default flavor from id to name

### DIFF
--- a/roles/openstack/nova/defaults/main.yml
+++ b/roles/openstack/nova/defaults/main.yml
@@ -11,5 +11,5 @@ wait: yes
 
 # Flavor defaults
 
-flavor_id: 4
+flavor_id: m1.large
 flavor_name: ir-flavor


### PR DESCRIPTION
It would be more accurate to point "m1.large" by name
rather than guessing it's id number 4.