### PR TITLE
[RHOSINFRA-150] Fixes wrong IP for same group hosts - openstack provisioner

### DIFF
--- a/playbooks/provisioner/openstack/main.yml
+++ b/playbooks/provisioner/openstack/main.yml
@@ -4,3 +4,15 @@
   roles:
       - { role: openstack/neutron, action: setup }
       - { role: openstack/nova, action: setup }
+
+- name: OpenStack Provisioner SSH wait
+  hosts: openstack_nodes
+  gather_facts: no
+  tasks:
+  - name: Wainting for OpenStack nodes to be SSH-ables
+    wait_for:
+        host: "{{ ansible_ssh_host }}"
+        port: 22
+        search_regex: OpenSSH
+        delay: 10
+    delegate_to: localhost

--- a/roles/openstack/nova/tasks/setup_nodes.yml
+++ b/roles/openstack/nova/tasks/setup_nodes.yml
@@ -40,12 +40,12 @@
       server: "{{ prefix }}{{ node_type.value.name }}*"
       cloud: "{{ provisioner.cloud | default(omit) }}"
   register: servers
-      
+
 - name: Add created servers to inventory
   add_host:
-      name: "{{ prefix }}{{ node_type.value.name}}-{{item}}"
-      ansible_ssh_host: "{{ servers.ansible_facts.openstack_servers[0].public_v4 }}"
+      name: "{{ item.name }}"
+      ansible_ssh_host: "{{ item.public_v4 }}"
       groups: "{{ provisioner.nodes[node_type.value.name].groups | join(',') }}"
       ansible_ssh_private_key_file: "{{ provisioner.key.file }}"
       ansible_ssh_user: 'cloud-user'
-  with_sequence: "count={{ node_type.value.amount }}"
+  with_items: "{{ servers.ansible_facts.openstack_servers }}"


### PR DESCRIPTION
With OpenStack provisioner hosts from same group get the same IP at the
'Add created servers to inventory' task.