### PR TITLE
[RHOSINFRA-147] ir-ci jenkins POC 

### DIFF
--- a/cli/ci.py
+++ b/cli/ci.py
@@ -1,0 +1,62 @@
+import ssl
+import jenkins
+
+from cli import logger
+
+LOG = logger.LOG
+
+
+class JenkinsRunner(object):
+    """
+    The jenkins job runner.
+
+    Starts jenkins jobs using Jenkins python API.
+    """
+    START_TIMEOUT = 10
+    BUILD_COMPLETION_TIMEOUT = 60*60*3
+    START_PULL = 1
+
+    def __init__(self, auth_info, ignore_ssh_warnings=True):
+        self.host = auth_info.get('url')
+        self.username = auth_info.get('username', None)
+        self.password = auth_info.get('password', None)
+
+        self.server = jenkins.Jenkins(
+            self.host,
+            username=self.username,
+            password=self.password)
+        # ignore ssl warnings
+        if ignore_ssh_warnings:
+            ssl._create_default_https_context = ssl._create_unverified_context
+        self.test_connection()
+
+    def build(self, job_name, job_parameters):
+        """
+        Starts the job build.
+
+        """
+        LOG.debug("Starting job '{}' on '{}' server...".format(
+            job_name, self.host))
+
+        self.server.build_job(job_name, job_parameters)
+        LOG.debug('Build has started or queued. Check job url: {}'.format(
+            self.get_job_info(job_name)['url']))
+
+    def get_build_info(self, job_name, build_number):
+        """
+        Get the build information
+        """
+
+        return self.server.get_build_info(job_name, build_number)
+
+    def get_job_info(self, job_name):
+        """
+        Gets the job information
+        """
+        return self.server.get_job_info(job_name)
+
+    def test_connection(self):
+        """
+        Tests the server connection
+        """
+        self.server.get_version()

--- a/cli/spec.py
+++ b/cli/spec.py
@@ -479,9 +479,10 @@ def override_default_values(clg_args, sub_parser_options):
             all_options=sub_parser_options)
     else:
         # Override defaults with the ini file args if provided
-        file_args = getattr(clg_args.get('from-file'), "value", {}).get(
-            clg_args['command0'], {})
-        utils.dict_merge(defaults, file_args)
+        from_file_arg = getattr(clg_args.get('from-file'), "value", {})
+        if from_file_arg is not None:
+            file_args = from_file_arg.get(clg_args['command0'], {})
+            utils.dict_merge(defaults, file_args)
 
         # Resolve defaults and load values to clg_args
         for arg_name, arg_obj in clg_args.iteritems():

--- a/infrared.cfg.example
+++ b/infrared.cfg.example
@@ -15,3 +15,7 @@ cleanup_playbook = cleanup.yml
 [installer]
 main_playbook = install.yml
 cleanup_playbook = cleanup.yml
+
+[ci]
+ignore_ssh_warnings = True
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ PyYAML>=3.11
 shade>=1.7.0
 yamlordereddictloader>=0.1.1
 requests>=2.9.1
-
+python-jenkins==0.4.12

--- a/settings/ci/jenkins/jenkins.spec
+++ b/settings/ci/jenkins/jenkins.spec
@@ -1,0 +1,13 @@
+subparsers:
+    jenkins:
+        formatter_class: RawTextHelpFormatter
+        help: Infrared integration with the jenkins ci
+        options:
+            config:
+                type: IniFile
+                help: the jenkins configuration and authentication info
+                required: yes
+            from-file:
+                type: IniFile
+                help: The file with the job parameters
+                required: yes


### PR DESCRIPTION
Jenkins job execution from CLI

Usage example:

``` shell
# generate conf file
ir-provisioner virsh --generate-conf-file=job_params.ini
ir-installler ospd --generate-conf-file=job_params.ini
# edit generated file and provide all the required args there
# create jenkins config file 
cat jenkins.ini
[jenkins]
url = http://10.8.180.145:8080/
username = obaranov
password = mypass
job_name = poc-ir-obaranov-distro

# run jenkins job
ir-ci -d jenkins --config=jenkins.ini --from-file=job_params.ini
```

Job POC: http://10.8.180.145:8080/job/poc-ir-obaranov-distro/

Known issues and limitation: 
1) Optional arguments should be manually added to the job_params.ini or handled on job itslef (see the images-url usage in job configuration) 
2) We pass job parameters as the environment variables to the infrared. So I think we need to have more unique names for these variables to avoid duplication from installer and provisioner. E.g. we have have the same flags in different specs and in this case we will lose one of them... 
