### PR TITLE
Get selinux binding during installation

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -33,12 +33,11 @@ to avoid corrupting the system packages::
   $ virtualenv .venv
   $ source .venv/bin/activate
 
-`Get python binding for SELinux <https://dmsimard.com/2016/01/08/selinux-python-virtualenv-chroot-and-ansible-dont-play-nice/>`_::
 
-  $ cp -rv /usr/lib64/python2.7/site-packages/selinux/ $VIRTUAL_ENV/lib/python2.7/site-packages
-
-
-.. note:: libselinux-python is in `Prerequisites`_ but doesn't have a pip package. Create virtualenv with site packages enabled to avoid this hack::
+.. note:: libselinux-python is in `Prerequisites`_ but doesn't have a pip package.
+ When detecting a virtualenv without selinux binding, InfraRed will try to
+ `get python binding from system <http://dmsimard.com/2016/01/08/selinux-python-virtualenv-chroot-and-ansible-dont-play-nice/>`_.
+ To avoid this, create an "open" virtualenv with site packages enabled::
 
   $ virtualenv --system-site-packages .venv
 

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,6 @@ except ImportError as e:
             "selinux")
         if not os.path.exists(SELINUX_PATH):
             raise new_error
-        print("missing selinux binding. Trying to pull modules from "
-                 "system ({source}) to virtualenv {dest}".format(
-            source=SELINUX_PATH, dest=sys.prefix))
 
         # filter precompiled files
         files = [f for f in os.listdir(SELINUX_PATH)
@@ -68,8 +65,6 @@ except ImportError as e:
         dest = os.path.join(VENV_SITE, "selinux")
         os.makedirs(dest)
         for f in files:
-            print("Copying {source} to {dest}".format(
-                source=f, dest=dest))
             shutil.copy(os.path.join(SELINUX_PATH, f),
                          dest)
     else:

--- a/setup.py
+++ b/setup.py
@@ -39,3 +39,39 @@ setup(
     author='rhos-qe',
     author_email='rhos-qe-dept@redhat.com'
 )
+
+try:
+    import selinux
+except ImportError as e:
+    new_error = type(e)(e.message + ". check that 'python-libselinux is "
+                                    "installed'")
+    import sys
+    import shutil
+    from distutils import sysconfig
+
+    if hasattr(sys, 'real_prefix'):
+        # check for venv
+        VENV_SITE = sysconfig.get_python_lib()
+        SELINUX_PATH = os.path.join(
+            sysconfig.get_python_lib(plat_specific=True,
+                                     prefix=sys.real_prefix),
+            "selinux")
+        if not os.path.exists(SELINUX_PATH):
+            raise new_error
+        print("missing selinux binding. Trying to pull modules from "
+                 "system ({source}) to virtualenv {dest}".format(
+            source=SELINUX_PATH, dest=sys.prefix))
+
+        # filter precompiled files
+        files = [f for f in os.listdir(SELINUX_PATH)
+                 if not os.path.splitext(f)[1] in (".pyc", ".pyo")]
+        dest = os.path.join(VENV_SITE, "selinux")
+        os.makedirs(dest)
+        for f in files:
+            print("Copying {source} to {dest}".format(
+                source=f, dest=dest))
+            shutil.copy(os.path.join(SELINUX_PATH, f),
+                         dest)
+    else:
+        raise new_error
+    import selinux

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from os.path import join, dirname, abspath
 from pip import req
+import platform
 from setuptools import setup, find_packages
 
 import cli
@@ -40,33 +41,35 @@ setup(
     author_email='rhos-qe-dept@redhat.com'
 )
 
-try:
-    import selinux
-except ImportError as e:
-    new_error = type(e)(e.message + ". check that 'python-libselinux is "
-                                    "installed'")
-    import sys
-    import shutil
-    from distutils import sysconfig
+if all(platform.linux_distribution(supported_dists="redhat")):
+    # For RedHat based systems, get selinux binding
+    try:
+        import selinux
+    except ImportError as e:
+        new_error = type(e)(e.message + ". check that 'python-libselinux is "
+                                        "installed'")
+        import sys
+        import shutil
+        from distutils import sysconfig
 
-    if hasattr(sys, 'real_prefix'):
-        # check for venv
-        VENV_SITE = sysconfig.get_python_lib()
-        SELINUX_PATH = os.path.join(
-            sysconfig.get_python_lib(plat_specific=True,
-                                     prefix=sys.real_prefix),
-            "selinux")
-        if not os.path.exists(SELINUX_PATH):
+        if hasattr(sys, 'real_prefix'):
+            # check for venv
+            VENV_SITE = sysconfig.get_python_lib()
+            SELINUX_PATH = os.path.join(
+                sysconfig.get_python_lib(plat_specific=True,
+                                         prefix=sys.real_prefix),
+                "selinux")
+            if not os.path.exists(SELINUX_PATH):
+                raise new_error
+
+            # filter precompiled files
+            files = [f for f in os.listdir(SELINUX_PATH)
+                     if not os.path.splitext(f)[1] in (".pyc", ".pyo")]
+            dest = os.path.join(VENV_SITE, "selinux")
+            os.makedirs(dest)
+            for f in files:
+                shutil.copy(os.path.join(SELINUX_PATH, f),
+                            dest)
+        else:
             raise new_error
-
-        # filter precompiled files
-        files = [f for f in os.listdir(SELINUX_PATH)
-                 if not os.path.splitext(f)[1] in (".pyc", ".pyo")]
-        dest = os.path.join(VENV_SITE, "selinux")
-        os.makedirs(dest)
-        for f in files:
-            shutil.copy(os.path.join(SELINUX_PATH, f),
-                         dest)
-    else:
-        raise new_error
-    import selinux
+        import selinux


### PR DESCRIPTION
File modules (copy/file/template) require selinux binding, which isn't
provided in pypy and thus unsupported by virtualenv.
Get it from system during installation.