### PR TITLE
Add tester

### DIFF
--- a/settings/provisioner/topology/tester.yml
+++ b/settings/provisioner/topology/tester.yml
@@ -1,0 +1,25 @@
+name: "tester"
+amount: "1"
+cpu: "8"
+memory: "8192"
+os:
+    type: "linux"
+    variant: "rhel7"
+disks:
+    disk1:
+        path: "/var/lib/libvirt/images"
+        dev: "/dev/vda"
+        size: "30G"
+network:
+    interfaces:
+        management:
+            label: "eth0"
+        data:
+            label: "eth1"
+        external:
+            label: "eth2"
+    floating_ip_network: management
+
+groups:
+    - tester
+    - openstack_nodes


### PR DESCRIPTION
Before this change, the only node in tester group
was undercloud.

There is a use case ( component testing ) for testing
on one provisioned node and this is way 'tester' node
was added to the topology.