### PR TITLE
Add 'dns' argument to OpenStack provisioner

### DIFF
--- a/roles/openstack/neutron/defaults/main.yml
+++ b/roles/openstack/neutron/defaults/main.yml
@@ -9,9 +9,6 @@ timeout_network: 180
 # Subnet defaults
 
 enable_dhcp: True
-dns_servers:
-    - 208.67.222.222
-    - 8.8.8.8
 
 # Router defaults
 

--- a/roles/openstack/neutron/tasks/setup.yml
+++ b/roles/openstack/neutron/tasks/setup.yml
@@ -32,7 +32,7 @@
       allocation_pool_end: "{{ item.value.allocation_pool_end }}"
       cidr: "{{ item.value.cidr | default(omit) }}"
       cloud: "{{ provisioner.cloud | default(omit) }}"
-      dns_nameservers: "{{ item.value.dns_servers | default(dns_servers) }}"
+      dns_nameservers: "{{ provisioner.dns }}"
       enable_dhcp: "{{ item.value.enable_dhcp | default(enable_dhcp) }}"
       name: "{{ prefix }}{{ item.value.name }}"
       network_name: "{{ prefix }}{{ item.value.network_name }}"

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -31,6 +31,12 @@ subparsers:
                       type: Value
                       help: An image id or name, on OpenStack cloud to provision the instance with. To see full list of images avaialable on the cloud, use 'glance image-list'.
                       required: yes
+            - title: dns
+              options:
+                  dns:
+                      type: Value
+                      help: The dns server the provisioned instances should use.
+                      default: 208.67.222.222
             - title: topology
               options:
                   neutron:


### PR DESCRIPTION
This allows users to specify their own DNS.