### PR TITLE
Small cleanup of beaker add_host module

### DIFF
--- a/playbooks/provisioner/beaker/main.yml
+++ b/playbooks/provisioner/beaker/main.yml
@@ -14,8 +14,6 @@
         ansible_ssh_host="{{ provisioner.fqdn }}"
         ansible_ssh_user="{{ provisioner.ssh_user }}"
         ansible_ssh_pass="{{ provisioner.ssh_password }}"
-        ansible_ssh_password="{{ provisioner.ssh_password }}"
-# TODO(aopincar): Figure out which one is redundant, ansible_ssh_pass or ansible_ssh_password
 
 - name: Use beaker to provision/release the machine
   hosts: localhost


### PR DESCRIPTION
There was redundant ansible_ssh_password parameter - this one is not
known by ansible.

See: http://docs.ansible.com/ansible/intro_inventory.html