### PR TITLE
Removes the use in 'ansible_ssh_password'

### DIFF
--- a/playbooks/provisioner/beaker/main.yml
+++ b/playbooks/provisioner/beaker/main.yml
@@ -47,7 +47,7 @@
       when: provisioner.ssh_key is defined
       delegate_to: localhost
 
-    - name: Copy SSH key  to authorized_key
+    - name: Copy SSH key to authorized_key
       authorized_key:
         key: "{{ cmd_reg.stdout }}"
         user: root

--- a/roles/provisioner/virsh/tasks/main.yml
+++ b/roles/provisioner/virsh/tasks/main.yml
@@ -69,7 +69,7 @@
       name="{{ item.item.item[0] }}"
       groups="{{ provisioner.topology.nodes['%s' % item.item.item[0].rstrip('1234567890')].groups | join(',') }}"
       ansible_ssh_user="root"
-      ansible_ssh_password="redhat"
+      ansible_ssh_pass="redhat"
       ansible_ssh_host="{{ item.stdout }}"
       ansible_ssh_private_key_file="{{ inventory_dir }}/id_rsa"
   when: item.item is defined and item.item.item[1] == "external"

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -7,7 +7,7 @@
  ansible_python_interpreter={{ hostvars[inventory_hostname]['ansible_python_interpreter'] }}
 {% endif %}
 {% else %}
-{{ host }} ansible_ssh_host={{ hostvars[host]['ansible_ssh_host'] }} ansible_ssh_user={{ hostvars[host]['ansible_ssh_user'] }} ansible_ssh_password={{ hostvars[host]['ansible_ssh_password'] }}
+{{ host }} ansible_ssh_host={{ hostvars[host]['ansible_ssh_host'] }} ansible_ssh_user={{ hostvars[host]['ansible_ssh_user'] }} ansible_ssh_pass={{ hostvars[host]['ansible_ssh_pass'] }}
 {%- if hostvars[inventory_hostname]['ansible_python_interpreter'] is defined %}
  ansible_python_interpreter={{ hostvars[inventory_hostname]['ansible_python_interpreter'] }}
 {% endif %}


### PR DESCRIPTION
Replaced it with 'ansible_ssh_pass'.

Pull request #194 broke the beaker provisioner module, because it
removed the use in 'ansible_ssh_password' from the beaker playbook
only, but there is a use of it in the 'inventory.j2' template.