### PR TITLE
[RHOSINFRA-107] Adds more informative message for wrong topology

### DIFF
--- a/cli/exceptions.py
+++ b/cli/exceptions.py
@@ -91,3 +91,14 @@ class IREmptySettingsFile(IRException):
     def __init__(self, file_path):
         super(self.__class__, self).__init__("Empty settings files are not "
                                              "allowed: {}".format(file_path))
+
+
+class IRWrongTopologyFormat(IRException):
+    def __init__(self, used_format):
+        message = \
+            "Wrong topology nodes format has been given - '{}'\n" \
+            "Topology format should be comma separated value in " \
+            "<count_type> form.\n" \
+            "Example:\n" \
+            "  '1_controller,2_compute,1_undercloud'".format(used_format)
+        super(self.__class__, self).__init__(message)

--- a/cli/spec.py
+++ b/cli/spec.py
@@ -1,4 +1,5 @@
 import ConfigParser
+import re
 from functools import total_ordering
 
 import clg
@@ -221,15 +222,14 @@ class TopologyArgument(ValueArgument):
                                     'topology')
         topology_dict = {}
         for topology_item in self.value.split(','):
-            if '_' in topology_item:
-                number, node_type = topology_item.split('_')
-            else:
-                raise exceptions.IRConfigurationException(
-                    "Topology node should be in format  <number>_<node role>. "
-                    "Current value: '{}' ".format(topology_item))
+            pattern = re.compile("^[0-9]+_[A-Za-z]+$")
+            if pattern.match(topology_item) is None:
+                raise exceptions.IRWrongTopologyFormat(self.value)
+
+            number, node_type = topology_item.split('_')
             # todo(obaraov): consider moving topology to config on constant.
-            topology_dict[node_type] = utils.load_yaml(node_type + ".yml",
-                                                       topology_dir)
+            topology_dict[node_type] = \
+                utils.load_yaml(node_type + ".yml", topology_dir)
             topology_dict[node_type]['amount'] = int(number)
 
         self.value = topology_dict


### PR DESCRIPTION
Message for wrong topology format is now more informative and includes an example of right usage.
Improved the topology format validation using regex.

Resolves RHOSINFRA-107