### PR TITLE
Update setuptools requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=11.3
 pytz>=2016.3
 shade>=1.7.0
 python-novaclient>=2.21.0,!=2.27.0,!=2.32.0


### PR DESCRIPTION
```
$ ir-provisioner -d -vvvv openstack -o provision.yml --image=rhel-guest-image-7.2-20151102.0 --cloud rhos-qe-ci --prefix=gate-infrared-246-br-RHOSINFRA-107-pr-205- --nodes=1_controller,2_compute '--key-file=~/.ssh/rhos-jenkins/id_rsa' --key-name=rhos-jenkins
Traceback (most recent call last):
   File "/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/bin/ir-provisioner", line 5, in <module>
     from pkg_resources import load_entry_point
   File "/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/lib/python2.7/site-packages/pkg_resources.py", line 2829, in <module>
     working_set = WorkingSet._build_master()
   File "/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/lib/python2.7/site-packages/pkg_resources.py", line 451, in _build_master
     return cls._build_from_requirements(__requires__)
   File "/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/lib/python2.7/site-packages/pkg_resources.py", line 464, in _build_from_requirements
     dists = ws.resolve(reqs, Environment())
   File "/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/lib/python2.7/site-packages/pkg_resources.py", line 643, in resolve
     raise VersionConflict(dist, req) # XXX put more info here
 pkg_resources.VersionConflict: (setuptools 3.6 (/home/rhos-ci/jenkins/shiningpanda/jobs/ef9c0e94/virtualenvs/d41d8cd9/lib/python2.7/site-packages), Requirement.parse('setuptools>=11.3'))

```