### PR TITLE
Change requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=11.3
 pytz>=2016.3
-shade>=1.7.0
+shade==1.7.0
 python-novaclient>=2.21.0,!=2.27.0,!=2.32.0
 ansible>=2.0.0,!=2.0.2
 clg>=2.0.0


### PR DESCRIPTION
We should use shade 1.7.0 since shade 1.8.0 breaks floating
IP creation.