### PR TITLE
Add "Fix addition / creation of authorized_keys" patch from master

### DIFF
--- a/playbooks/installer/ospd/virthost.yml
+++ b/playbooks/installer/ospd/virthost.yml
@@ -116,5 +116,7 @@
         lineinfile:
             dest: "/home/{{ installer.user.name }}/.ssh/authorized_keys"
             line: "{{ undercloud_public_key.stdout }}"
+            create: yes
+            mode: o-rwx,g-rwx,u+rw
         become: yes
         become_user: "{{ installer.user.name }}"


### PR DESCRIPTION
We need to fix this asap as deployment is failing for users
with non-prepared slaves (like cleanly reprovisioned nodes).
Our slaves doesn't have this problem, this file exists there.

Part of Arx's PR proposed here:
https://github.com/rhosqeauto/InfraRed/pull/215/commits/8c87edacfddd59e27c511533de42c71666db7ab2