### PR TITLE
[RHOSINFRA-153] CLG rework

### DIFF
--- a/cli/ngclg.py
+++ b/cli/ngclg.py
@@ -1,0 +1,749 @@
+"""
+This module is used to read command line arguments and validate them
+according to the specification (spec) files.
+"""
+
+import argparse
+import collections
+import ConfigParser
+import glob
+import os
+import re
+import sys
+import yaml
+from copy import deepcopy
+
+from cli import utils, logger, exceptions
+
+LOG = logger.LOG
+
+BUILTINS = sys.modules[
+    'builtins' if sys.version_info.major == 3 else '__builtin__']
+TYPES = {builtin: getattr(BUILTINS, builtin) for builtin in vars(BUILTINS)}
+TYPES['suppress'] = argparse.SUPPRESS
+
+OPTION_ARGPARSE_ATTRIBUTES = ['action', 'nargs', 'const', 'default', 'choices',
+                              'required', 'help', 'metavar', 'type', 'version']
+
+
+class Spec(object):
+    """
+    The spec manager.
+    """
+
+    @classmethod
+    def from_folder(cls, settings_folder, app_name, file_ext='spec'):
+        """
+        Reads spec file from the settings folder and generate Spec object.
+        :param settings_folder: the root settings file
+        :param app_name: the application name (provisioner/installer/tester)
+        :param file_ext: the spec file extension.
+        :return: the Spec instance.
+        """
+        # look for common specs in the root of the settings file
+        spec_files = []
+        spec_files.extend(glob.glob('./' + settings_folder + '/*' + file_ext))
+
+        # look for all the spec files for an app
+        root_folder = os.path.join(settings_folder, app_name)
+
+        for root, _, files in os.walk(root_folder):
+            spec_files.extend([os.path.join(root, a_file) for a_file in files
+                               if a_file.endswith(file_ext)])
+
+        return cls.from_files(settings_folder, app_name, *spec_files)
+
+    @classmethod
+    def from_files(cls, settings_folder, app_name, *spec_files):
+        """
+        Reads specs files and constructs the parser isinstance
+        """
+        result = {}
+        for spec_file in spec_files:
+            with open(spec_file) as stream:
+                spec = yaml.load(stream)
+                utils.dict_merge(
+                    result, spec, utils.ConflictResolver.append_list_resolver)
+
+        return Spec(result, settings_folder, app_name)
+
+    def __init__(self, spec_dict, settings_folder, app_name):
+        self.app_name = app_name
+        self.settings_folder = settings_folder
+        self.spec_dict = spec_dict
+        self.validate_spec()
+        # make structure of the dict flat
+        # 1. handle include_groups directive in root parser
+        parser_dict = self.spec_dict['command']
+        self._include_groups(parser_dict)
+        # 2. Include groups for all subparsers
+        for subparser in parser_dict.get('subcommands', []):
+            self._include_groups(subparser)
+
+    def _include_groups(self, parser_dict):
+        for group in parser_dict.get('include_groups', []):
+            # ensure we have that group
+            grp_dict = next(
+                (grp for grp in self.spec_dict['groups']
+                 if grp['name'] == group),
+                None)
+            if grp_dict is None:
+                raise SpecParserException(
+                    "Unable to include group '{}' in '{}' parser. "
+                    "Group was not found!".format(
+                        group,
+                        parser_dict['name']))
+
+            parser_groups_list = parser_dict.get('groups', [])
+            parser_groups_list.append(grp_dict)
+            parser_dict['groups'] = parser_groups_list
+
+    def _get_all_options(self, parser_dict):
+        result = []
+        for group in parser_dict.get('groups', []):
+            for option in group.get('options', []):
+                result.append(option)
+        return result
+
+    def _get_parser_options(self, parser_name):
+        options = []
+        if parser_name == 'root':
+            options = self._get_all_options(self.spec_dict['command'])
+        else:
+            for subparser in self.spec_dict['command'].get('subcommands', []):
+                if subparser['name'] == parser_name:
+                    options = self._get_all_options(subparser)
+                    break
+        return options
+
+    def _get_defaults(self, default_getter_func):
+        """
+        Gets the defaults value according to the spec file.
+        """
+
+        def process_parser(parser_dict, is_subparser):
+            """
+            Retrieves default values from a parser.
+            """
+            result = collections.defaultdict(dict)
+            all_options = self._get_all_options(parser_dict)
+            for option in all_options:
+                default_value = default_getter_func(option)
+                if default_value is not None:
+                    if is_subparser:
+                        sub = parser_dict['name']
+                        result[sub][option['name']] = default_value
+                    else:
+                        result['root'][option['name']] = default_value
+
+            return result
+
+        res = process_parser(self.spec_dict['command'], False)
+        for subparser in self.spec_dict['command'].get('subcommands', []):
+            utils.dict_merge(
+                res,
+                process_parser(subparser, True))
+        return res
+
+    def get_env_defaults(self):
+        """
+        Gets the argument's  defaults values from the environment.
+        """
+
+        def env_getter(option):
+            """
+            The getter fucntion to retrieve the env varible for arument.
+            """
+            env_name = option['name'].replace('-', '_').upper()
+            return os.environ.get(env_name, None)
+
+        return self._get_defaults(env_getter)
+
+    def get_spec_defaults(self):
+        """
+        Gets the arguments defaults value from the spec and other sources.
+        """
+
+        def spec_default_getter(option):
+            """
+            The getter function to retrieve the default value from spec
+            """
+            default_value = None
+            if option.get('default', None) is not None:
+                default_value = option['default']
+            elif option.get('action', None) in ['store_true']:
+                default_value = False
+            return default_value
+
+        return self._get_defaults(spec_default_getter)
+
+    def get_config_args(self, cli_args):
+        """
+        Gets the args's from the configuration file
+        """
+        condig_options = {}
+        condig_options['root'] = filter(
+            lambda option: option.get('action', None) == 'read-config',
+            self._get_all_options(self.spec_dict['command']))
+        for subparser in self.spec_dict['command'].get('subcommands', []):
+            condig_options[subparser['name']] = filter(
+                lambda option: option.get('action', None) == 'read-config',
+                self._get_all_options(subparser))
+
+        # now check what parser we have from cli
+        file_result = collections.defaultdict(dict)
+        for parser_name, parser_args_dict in cli_args.items():
+            for file_option in condig_options.get(parser_name, []):
+                if file_option['name'] in parser_args_dict:
+                    # we have config option. saving it.
+                    utils.dict_merge(
+                        file_result[parser_name],
+                        parser_args_dict[file_option['name']])
+                    # remove from cli args
+                    parser_args_dict.pop(file_option['name'])
+
+        return file_result
+
+    def generate_config_file(self, cli_args, spec_defaults):
+
+        def put_option(out_config, parser_name, opt_name, value):
+            for opt_help in option.get('help', '').split('\n'):
+                help_opt = '# ' + opt_help
+
+                # add help comment
+                if out_config.has_option(parser_name, help_opt):
+                    out_config.remove_option(help_opt)
+                out_config.set(
+                    parser_name, help_opt)
+
+            if out_config.has_option(parser_name, opt_name):
+                value = out_config.get(parser_name, opt_name)
+                out_config.remove_option(parser_name, opt_name)
+
+            out_config.set(
+                parser_name,
+                opt_name,
+                value)
+
+        file_generated = False
+        condig_options = {}
+        condig_options['root'] = filter(
+            lambda option: option.get('action', None) == 'generate-config',
+            self._get_all_options(self.spec_dict['command']))
+        for subparser in self.spec_dict['command'].get('subcommands', []):
+            condig_options[subparser['name']] = filter(
+                lambda option: option.get('action', None) == 'generate-config',
+                self._get_all_options(subparser))
+
+        # load generate config file for all the parsers
+        for parser_name, parser_args_dict in cli_args.items():
+            for generate_option in condig_options.get(parser_name, []):
+                if generate_option['name'] in parser_args_dict:
+                    # we have to generate config.
+                    # put command default arguments to the file
+                    options_to_save = self._get_parser_options(parser_name)
+                    out_config = ConfigParser.ConfigParser(allow_no_value=True)
+                    file_name = parser_args_dict[generate_option['name']]
+
+                    if os.path.exists(file_name):
+                        # todo(obaranov) comments from other section will be
+                        # removed.
+                        out_config.read(file_name)
+
+                    if not out_config.has_section(parser_name):
+                        out_config.add_section(parser_name)
+
+                    for option in options_to_save:
+                        opt_name = option['name']
+                        if opt_name in spec_defaults[parser_name]:
+                            put_option(
+                                out_config,
+                                parser_name,
+                                opt_name,
+                                spec_defaults[parser_name][opt_name])
+                        elif option.get('required', False):
+                            put_option(
+                                out_config,
+                                parser_name,
+                                opt_name,
+                                "Required argument. "
+                                "Edit with one of the allowed values OR "
+                                "override with "
+                                "CLI: --{}=<option>".format(opt_name))
+
+                    with open(file_name, 'w') as configfile:  # save
+                        out_config.write(configfile)
+                    file_generated = True
+        return file_generated
+
+    def resolve_complex_types(self, args):
+        # todo (obaranov) remove hardcoded settings.
+        for parser_name, parser_dict in args.items():
+            spec_complex_options = [opt for opt in
+                                    self._get_parser_options(parser_name) if
+                                    opt.get('complex_type', None)]
+            for spec_option in spec_complex_options:
+                option_name = spec_option['name']
+                if option_name in parser_dict:
+                    # we have complex action to resolve
+                    type_name = spec_option['complex_type']
+                    option_value = parser_dict[option_name]
+                    action = self.create_complex_action(
+                        parser_name,
+                        type_name,
+                        option_name)
+
+                    # resolving value
+                    parser_dict[option_name] = action.resolve(option_value)
+
+    def create_complex_action(self, subcommand, type_name, option_name):
+        complex_action = COMPLEX_TYPES.get(
+            type_name, None)
+        if complex_action is None:
+            raise SpecParserException(
+                "Unknown complex type: {}".format(
+                    type_name))
+        return complex_action(
+            option_name,
+            self.settings_folder,
+            self.app_name,
+            subcommand)
+
+    def parse_args(self):
+        spec_defaults = self.get_spec_defaults()
+        env_defaults = self.get_env_defaults()
+        cli_args = CliParser.parse_args(self)
+
+        file_args = self.get_config_args(cli_args)
+
+        # generate config file if arg is present and exit
+        if self.generate_config_file(cli_args, spec_defaults):
+            LOG.warning("Config file generated. Exiting.")
+            return None
+
+        # print warnings when something was overridden from non-cli source.
+        self.validate_arg_sources(cli_args,
+                                  env_defaults,
+                                  file_args,
+                                  spec_defaults)
+
+        # merge defaults into one
+        utils.dict_merge(spec_defaults, env_defaults)
+        # now filter defaults to have only parser defined in cli
+        defaults = {key: spec_defaults[key] for key in cli_args.keys()}
+
+        utils.dict_merge(defaults, file_args)
+        utils.dict_merge(defaults, cli_args)
+        self.validate_requires_args(defaults)
+
+        # now resolve complex types.
+        self.resolve_complex_types(defaults)
+        return defaults
+
+    def validate_arg_sources(self, cli_args, env_defaults, file_args,
+                             spec_defaults):
+
+        def warn_diff(diff, command_name, cmd_dict, source_name):
+            if diff:
+                for arg_name in diff:
+                    value = cmd_dict[arg_name]
+                    LOG.warning(
+                        "[{}] Argument '{}' was set to"
+                        " '{}' from the {} source.".format(
+                            command_name, arg_name, value, source_name))
+
+        for command, command_dict in cli_args.items():
+            file_dict = file_args.get(command, {})
+            self.validate_unrecognized_arguments(command, file_dict)
+            file_diff = set(file_dict.keys()) - set(command_dict.keys())
+            warn_diff(file_diff, command, file_dict, 'config file')
+
+            env_dict = env_defaults.get(command, {})
+            env_diff = set(env_dict.keys()) - set(
+                command_dict.keys()) - file_diff
+            warn_diff(env_diff, command, env_dict, 'environment variables')
+
+            def_dict = spec_defaults.get(command, {})
+            default_diff = set(def_dict.keys()) - set(
+                command_dict.keys()) - file_diff - env_diff
+            warn_diff(default_diff, command, def_dict, 'spec defaults')
+
+    def validate_spec(self):
+        """
+        Validates the specification.
+        """
+        assert 'command' in self.spec_dict
+
+    def validate_unrecognized_arguments(self, command_name, command_dict):
+        # get expected options
+        if command_name == 'root':
+            options = self._get_all_options(self.spec_dict['command'])
+        else:
+            subparser = next((subparser for subparser in
+                              self.spec_dict['command'].get('subcommands', [])
+                              if subparser['name'] == command_name), None)
+            options = self._get_all_options(subparser)
+
+        options = map(lambda opt: opt['name'], options)
+        for arg_name, arg_value in command_dict.items():
+            if arg_name not in options:
+                LOG.warning(
+                    "[{}] Unrecognized argument in config file: '{}'. "
+                    "Ignoring.".format(command_name, arg_name))
+                command_dict.pop(arg_name)
+
+    def validate_requires_args(self, args):
+        """
+        Validates the resulting args.
+        :return:
+        """
+
+        def validate_parser(parser_name, expected_options, parser_args):
+            result = True
+            for option in expected_options:
+                name = option['name']
+
+                # check required options.
+                if option.get('required', False) and name not in parser_args:
+                    LOG.error(
+                        "Required argument '{}' is not set "
+                        "for '{}' command".format(name, parser_name))
+                    result = False
+
+            if not result:
+                LOG.warning(
+                    "Received arguments for "
+                    "'{}' command: {}".format(parser_name, parser_args))
+
+            return result
+
+        # go through the options from spec.
+        root_options = self._get_all_options(self.spec_dict['command'])
+        validate_parser('root', root_options, args['root'])
+        res = True
+        for subparser in self.spec_dict['command'].get('subcommands', []):
+            sub_name = subparser['name']
+            if sub_name in args:
+                res = validate_parser(sub_name,
+                                      self._get_all_options(subparser),
+                                      args[sub_name])
+        if not res:
+            os._exit(1)
+
+
+class CliParser(object):
+    """
+    Allows to handle the CLI arguments.
+    """
+
+    @classmethod
+    def parse_args(cls, spec):
+        parser_dict = spec.spec_dict['command']
+        arg_parser = argparse.ArgumentParser(
+            description=parser_dict.get(
+                'description', ''),
+            formatter_class=parser_dict.get(
+                'formatter_class', argparse.RawTextHelpFormatter))
+
+        cls._add_groups(spec, arg_parser, parser_dict)
+
+        # process subparsers
+        subparsers = parser_dict.get('subcommands', [])
+        if subparsers:
+            dest_path = 'command0'
+            arg_subparser = arg_parser.add_subparsers(dest=dest_path)
+
+            for subparser_dict in parser_dict.get('subcommands', []):
+                cmd_parser = arg_subparser.add_parser(
+                    subparser_dict['name'],
+                    help=subparser_dict.get('help', ''),
+                    description=subparser_dict.get('description', ''),
+                    formatter_class=parser_dict.get(
+                        'formatter_class', argparse.RawTextHelpFormatter))
+
+                cls._add_groups(
+                    spec,
+                    cmd_parser,
+                    subparser_dict,
+                    path_prefix=dest_path)
+        # finally get the args
+        parse_args = arg_parser.parse_args().__dict__
+
+        # move sub commands to the nested dicts
+        result = collections.defaultdict(dict)
+        expr = '^(?P<subcmd_name>command[0-9])+(?P<arg_name>.*)$$'
+        for arg, value in parse_args.items():
+            if value is None:
+                continue
+            match = re.search(expr, arg)
+            if match and match.groupdict().get('subcmd_name', None) \
+                    and not match.groupdict().get('arg_name', None):
+                # create empty nested dict for subcommands
+                if value not in result:
+                    result[value] = {}
+            if match and match.groupdict().get('arg_name', None):
+                # we have subcommand. put it as nested dict
+                arg_name = match.group('arg_name')
+                cmd_name = match.group('subcmd_name')
+                sub_name = parse_args[cmd_name]
+                result[sub_name][arg_name] = value
+            else:
+                result['root'][arg] = value
+
+        return result
+
+    @classmethod
+    def _add_groups(cls, spec, arg_parser, parser_data, path_prefix=''):
+        """
+        Adds groups to the parser.
+        """
+        options = []
+        # add 'private' parser groups
+        for grp_dict in parser_data.get('groups', []):
+            group = arg_parser.add_argument_group(grp_dict['name'])
+            # add options to the group
+            for opt_dict in grp_dict.get('options', []):
+                options.append(
+                    cls._add_argument(spec, parser_data.get('name', 'root'),
+                                      group, opt_dict, path_prefix))
+        return options
+
+    @classmethod
+    def _add_argument(cls, spec, subparser, group, option_data,
+                      path_prefix=''):
+        """
+        Adds argument to the group.
+        """
+        opt_args = []
+        opt_kwargs = {}
+        if 'short' in option_data:
+            opt_args.append('-{}'.format(option_data['short']))
+        opt_args.append('--{}'.format(option_data['name']))
+
+        # add prefix to ensure we can group subcommand arguments later
+        opt_kwargs['dest'] = option_data.get(
+            'dest', path_prefix + option_data['name'])
+        if 'type' in option_data:
+            opt_kwargs['type'] = TYPES.get(option_data['type'])
+
+        for option_key in OPTION_ARGPARSE_ATTRIBUTES:
+            if option_key != 'type' and option_key in option_data:
+                opt_kwargs[option_key] = option_data[option_key]
+        # set correct metavar to have correct name in the usage statement
+        if 'metavar' not in opt_kwargs and \
+                opt_kwargs.get('action', None) not in \
+                ['count', 'help', 'store_true']:
+            opt_kwargs['metavar'] = option_data['name'].upper()
+
+        # resolve custom action
+        if 'action' in opt_kwargs and opt_kwargs['action'] in ACTIONS:
+            opt_kwargs['action'] = ACTIONS[opt_kwargs['action']]
+
+        # print default values to the help
+        if opt_kwargs.get('default', None):
+            opt_kwargs['help'] += "\nDefault value: {}".format(
+                opt_kwargs['default'])
+
+        # put allowed values to the help.
+        allowed_values = []
+        if opt_kwargs.get('choices', None):
+            allowed_values = opt_kwargs['choices']
+        elif option_data.get('complex_type', None):
+            action = spec.create_complex_action(
+                subparser,
+                option_data['complex_type'],
+                option_data['name'])
+
+            # resolving value
+            allowed_values = action.get_allowed_values()
+
+        if allowed_values:
+            opt_kwargs['help'] += "\nAllowed values: {}".format(
+                allowed_values)
+
+        # update help
+        option_data['help'] = opt_kwargs['help']
+
+        # pop default
+        result = deepcopy(opt_kwargs)
+        if not any(arg in sys.argv for arg in ['-h', '--help']):
+            opt_kwargs.pop('default', None)
+            opt_kwargs['default'] = argparse.SUPPRESS
+            opt_kwargs.pop('required', None)
+
+        group.add_argument(*opt_args, **opt_kwargs)
+        return result
+
+
+class SpecParserException(Exception):
+    """
+    The spec parser specific exception.
+    """
+    pass
+
+
+# custom argparse actions
+class ReadConfigAction(argparse.Action):
+    """
+    Custom action to read configuration file and
+    inject arguments into argparse from file
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # reading file
+        _config = ConfigParser.ConfigParser()
+        with open(values) as fd:
+            _config.readfp(fd)
+        # todo(obaranov) add different file types loaders
+        res_dict = {}
+        # load only section for a given subcommand
+        # todo(obaranov) consider resolving that in more intelligent way
+        progs = parser.prog.split()
+        subcommand = progs[-1]
+
+        if subcommand in _config._sections:
+            for option, val in _config.items(subcommand):
+                # todo(obaranov) checking if val is list (for extra-vars).
+                # rework that check to be more beautiful later.
+                if val.startswith('[') and val.endswith(']'):
+                    val = eval(str(val))
+                res_dict[option] = val
+
+            res_dict.pop('__name__', None)
+        # saving
+        setattr(namespace, self.dest, res_dict)
+
+
+class GenerateConfigAction(argparse._StoreAction):
+    """
+    Placeholder to identify an action to generate
+    config file with the default values
+    """
+    pass
+
+
+# Standard complex types
+class ComplexType(object):
+    """
+    Base complex type.
+
+    Complex accept additional input arguments beside the argument value
+    """
+
+    def __init__(self, arg_name,
+                 settings_dir,
+                 app_name,
+                 sub_command_name):
+        self.arg_name = arg_name
+        self.sub_command_name = sub_command_name
+        self.app_name = app_name
+        self.settings_dir = settings_dir
+
+    def resolve(self, value):
+        """
+        Resolves the value of the complex type.
+        :return: the resulting complex type value.
+        """
+        raise NotImplemented()
+
+    def get_allowed_values(self):
+        """
+        Gets the list of possible values for the complex type.
+
+        Should be overridden in the subclasses.
+        """
+        return []
+
+
+class YamlFile(ComplexType):
+    """
+    The complex type for yaml arguments.
+    """
+
+    FILE_EXTENSION = ['yml', 'yaml']
+
+    def get_file_locations(self):
+        """
+        Get the possible locations (folders) where the
+        yaml files can be stored.
+        """
+
+        base_dir = os.path.join(self.settings_dir, self.app_name)
+        search_first = os.path.join(base_dir,
+                                    self.sub_command_name,
+                                    *self.arg_name.split("-"))
+        search_second = os.path.join(base_dir,
+                                     *self.arg_name.split("-"))
+        return search_first, search_second, "."
+
+    def resolve(self, value):
+        """
+        Transforms yaml file to the dict
+        :return:
+        """
+        search_paths = self.get_file_locations()
+        return utils.load_yaml(value,
+                               *search_paths)
+
+    def get_allowed_values(self):
+        res = []
+
+        # except the root folder where we can have a lot of yaml files.
+        locations = self.get_file_locations()[:-1]
+
+        for folder in locations:
+            for ext in self.FILE_EXTENSION:
+                res.extend(glob.glob(folder + "/*." + ext))
+
+        return map(os.path.basename, res)
+
+
+class Topology(ComplexType):
+    """
+    Represents the topology complex type.
+    """
+
+    def resolve(self, value):
+        """
+        Reads the topology data.
+        """
+        topology_dir = os.path.join(
+            self.settings_dir, self.app_name, 'topology')
+        topology_dict = {}
+        for topology_item in value.split(','):
+
+            node_type, number = None, None
+
+            pattern = re.compile("^[A-Za-z]+:[0-9]+$")
+            if pattern.match(topology_item) is None:
+                pattern = re.compile("^[0-9]+_[A-Za-z]+$")
+                if pattern.match(topology_item) is None:
+                    raise exceptions.IRWrongTopologyFormat(value)
+                number, node_type = topology_item.split('_')
+                LOG.warning("This topology format is deprecated and will be "
+                            "removed in future versions. Please see `--help` "
+                            "for proper format")
+            else:
+                node_type, number = topology_item.split(':')
+
+            # Remove white spaces
+            node_type = node_type.strip()
+
+            # todo(obaraov): consider moving topology to config on constant.
+            topology_dict[node_type] = \
+                utils.load_yaml(node_type + ".yml", topology_dir)
+            topology_dict[node_type]['amount'] = int(number)
+
+        return topology_dict
+
+
+# register custom actions
+ACTIONS = {
+    'read-config': ReadConfigAction,
+    'generate-config': GenerateConfigAction
+}
+
+COMPLEX_TYPES = {
+    'YamlFile': YamlFile,
+    'Topology': Topology
+}

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -64,6 +64,16 @@ class ConflictResolver(object):
         """
         first[key] = second[key]
 
+    @staticmethod
+    def append_list_resolver(first, second, key):
+        if isinstance(first[key], list):
+            if isinstance(second[key], list):
+                first[key].extend(second[key])
+            else:
+                first[key].extend(second[key])
+        else:
+            return ConflictResolver.greedy_resolver(first, second, key)
+
 
 def dict_merge(first, second,
                conflict_resolver=ConflictResolver.greedy_resolver):

--- a/settings/base.spec
+++ b/settings/base.spec
@@ -1,11 +1,53 @@
 ---
-options:
-    verbose:
-        help: 'Control Ansible verbosity level'
-        short: v
-        action: count
-        default: 0
-    debug:
-        help: 'Run InfraRed in DEBUG mode'
-        short: d
-        action: store_true
+groups:
+    - name: Logging arguments
+      options:
+          - name: verbose
+            help: 'Control Ansible verbosity level'
+            short: v
+            action: count
+            default: 0
+          - name: debug
+            help: 'Run InfraRed in DEBUG mode'
+            short: d
+            action: store_true
+
+    - name: Inventory arguments
+      options:
+          - name: inventory
+            help: 'Inventory file'
+            type: str
+            default: local_hosts
+
+    - name: Common arguments
+      options:
+          - name: dry-run
+            action: store_true
+            help: Only generate settings, skip the playbook execution stage
+          - name: cleanup
+            action: store_true
+            help: Clean given system instead of running playbooks on  a new one
+          - name: input
+            action: append
+            type: str
+            short: i
+            help: Input settings file to be loaded before the merging of user args
+          - name: output
+            type: str
+            short: o
+            help: 'File to dump the generated settings into (default: stdout)'
+          - name: extra-vars
+            action: append
+            short: e
+            help: Extra variables to be merged last
+            type: str
+
+    - name: Configuration file arguments
+      options:
+          - name: from-file
+            action: read-config
+            help: reads arguments from file.
+          - name: generate-conf-file
+            action: generate-config
+            help: generate configuration file with default values
+

--- a/settings/installer/installer.spec
+++ b/settings/installer/installer.spec
@@ -1,6 +1,3 @@
----
-options:
-    inventory:
-        help: 'Inventory file (default: __DEFAULT__)'
-        type: str
-        default: hosts
+command:
+    description: Spec to install OpenStacks using different installers
+    include_groups: ['Logging arguments']

--- a/settings/installer/ospd/ospd.spec
+++ b/settings/installer/ospd/ospd.spec
@@ -1,135 +1,96 @@
 ---
-subparsers:
-    ospd:
-        formatter_class: RawTextHelpFormatter
-        help: Installs openstack using OSP Director
-        groups:
-            - title: Firewall
+command:
+    subcommands:
+        - name: ospd
+          help: Installs openstack using OSP Director
+          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
+          groups:
+            - name: Firewall
               options:
-                firewall:
-                    type: YamlFile
+                  - name: firewall
+                    complex_type: YamlFile
                     help: The firewall configuration
                     default: default.yml
 
-            - title: Product
+            - name: Product
               options:
-                product-version:
-                    type: Value
+                  - name: product-version
                     help: The product version
                     required: yes
                     choices: ["7", "8", "9"]
-                product-build:
-                    type: Value
+                  - name: product-build
                     help: The product build
                     default: latest
-                product-core-version:
-                    type: Value
+                  - name: product-core-version
                     help: The product core version
                     required: yes
                     choices: ["7", "8", "9"]
-                product-core-build:
-                    type: Value
+                  - name: product-core-build
                     help: The product core build
                     default: latest
 
-            - title: Undercloud
+            - name: Undercloud
               options:
-                undercloud-config:
-                    type: YamlFile
+                  - name: undercloud-config
+                    complex_type: YamlFile
                     help: The undercloud config details
                     default: default.yml
 
-            - title: Overcloud
+            - name: Overcloud
               options:
-                overcloud-ssl:
-                    type: Value
+                  - name: overcloud-ssl
                     help: Specifies whether ths SSL should be used for overcloud
                     default: 'no'
 
-            - title: Overcloud storage
+            - name: Overcloud storage
               options:
-                storage:
-                    type: YamlFile
+                  - name: storage
+                    complex_type: YamlFile
                     help: The overcloud storage type
                     default: no-storage.yml
 
-            - title: Product images
+            - name: Product images
               options:
-                images-task:
-                    type: Value
+                  - name: images-task
                     help: Specifies whether the images should be built or imported
                     required: yes
                     choices: [import, build]
-                images-url:
-                    type: Value
+                  - name: images-url
                     help: Specifies the import image url. Required only when images task is 'import'
 
-            - title: Overcloud Network
+            - name: Overcloud Network
               options:
-                network-backend:
-                    type: Value
+                  - name: network-backend
                     help: The overcloud network backend.
                     default: vxlan
-                network-protocol:
-                    type: Value
+                  - name: network-protocol
                     help: The network protocol for overcloud
                     default: ipv4
-                network-isolation:
-                    type: YamlFile
+                  - name: network-isolation
+                    complex_type: YamlFile
                     help: The overcloud network isolation type
                     required: yes
-                network-isolation-template:
-                    type: YamlFile
+                  - name: network-isolation-template
+                    complex_type: YamlFile
                     help: The overcloud network isolation template
 
-            - title: User
+            - name: User
               options:
-                user-name:
-                    type: Value
+                  - name: user-name
                     help: The installation user name
                     default: stack
-                user-password:
-                    type: Value
+                  - name: user-password
                     help: The installation user password
                     default: stack
 
-            - title: Loadbalancer
+            - name: Loadbalancer
               options:
-                loadbalancer:
-                    type: YamlFile
+                  - name: loadbalancer
+                    complex_type: YamlFile
                     help: The loadbalancer to use
 
-            - title: Workarounds
+            - name: Workarounds
               options:
-                workarounds:
-                    type: YamlFile
+                  - name: workarounds
+                    complex_type: YamlFile
                     help: The list of workarounds to use during install
-
-            - title: common
-              options:
-                  dry-run:
-                      action: store_true
-                      help: Only generate settings, skip the playbook execution stage
-                  cleanup:
-                      action: store_true
-                      help: Clean given system instead of provisioning a new one
-                  input:
-                      action: append
-                      type: str
-                      short: i
-                      help: Input settings file to be loaded before the merging of user args
-                  output:
-                      type: str
-                      short: o
-                      help: 'File to dump the generated settings into (default: stdout)'
-                  extra-vars:
-                      action: append
-                      short: e
-                      help: Extra variables to be merged last
-                      type: str
-                  from-file:
-                      type: IniFile
-                      help: the ini file with the list of arguments
-                  generate-conf-file:
-                      type: str
-                      help: generate configuration file (ini) containing default values and exits. This file is than can be used with the from-file argument

--- a/settings/provisioner/beaker/beaker.spec
+++ b/settings/provisioner/beaker/beaker.spec
@@ -1,66 +1,33 @@
 ---
-subparsers:
-    beaker:
-        help: Provision systems using Beaker
-        groups:
-            - title: Beaker server
-              options:
-                  base-url:
-                      type: Value
+command:
+    subcommands:
+        - name: beaker
+          help: Provision systems using Beaker
+          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
+          groups:
+              - name: Beaker server
+                options:
+                    - name: base-url
                       help: Base URL of Beaker server
                       required: True
-                  username:
-                      type: Value
+                    - name: username
                       help: 'Login username to authenticate to Beaker (default: __DEFAULT__)'
                       default: admin
-                  password:
-                      type: Value
+                    - name: password
                       help: Password of login user
                       required: True
-                  web-service:
-                      type: Value
+                    - name: web-service
                       help: Web service
                       default: 'rest'
                       choices: ['rest', 'rpc']
-                  ca-cert:
-                      type: Value
+                    - name: ca-cert
                       help: CA Certificate
                       required: False
-            - title: Beaker system
-              options:
-                  fqdn:
-                      type: Value
+              - name: Beaker system
+                options:
+                    - name: fqdn
                       help: Fully qualified domain name of a system
                       required: True
-                  distro-tree:
-                      type: Value
+                    - name: distro-tree
                       help: Distro Tree ID
                       default: 71576
-            - title: common
-              options:
-                  dry-run:
-                      action: store_true
-                      help: Only generate settings, skip the playbook execution stage
-                  cleanup:
-                      action: store_true
-                      help: Release the system
-                  input:
-                      action: append
-                      type: str
-                      short: i
-                      help: Input settings file to be loaded before the merging of user args
-                  output:
-                      type: str
-                      short: o
-                      help: 'File to dump the generated settings into (default: stdout)'
-                  extra-vars:
-                      action: append
-                      short: e
-                      help: Extra variables to be merged last
-                      type: str
-                  from-file:
-                      type: IniFile
-                      help: the ini file with the list of arguments
-                  generate-conf-file:
-                      type: str
-                      help: generate configuration file (ini) containing default values and exits. This file is than can be used with the from-file argument

--- a/settings/provisioner/foreman/foreman.spec
+++ b/settings/provisioner/foreman/foreman.spec
@@ -1,64 +1,35 @@
 ---
-subparsers:
-    foreman:
-        help: Provision systems using Foreman
-        groups:
-            - title: foreman
-              options:
-                  user:
-                      type: Value
+command:
+    subcommands:
+        - name: foreman
+          help: Provision systems using Foreman
+          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
+          groups:
+              - name: foreman
+                options:
+                    - name: user
                       help: User to Forman server
                       required: True
-                  password:
-                      type: Value
+                    - name: password
                       help: Password of Forman server
                       required: True
-                  url:
-                      type: Value
+                    - name: url
                       help: The Foreman api url
                       required: True
-                  strategy:
-                      type: Value
+                    - name: strategy
                       help: Whether to use Foreman or system ipmi command.
                       default: foreman
-                  action:
-                      type: Value
+                    - name: action
                       help: Which command to send with the power-management selected by mgmt_strategy. For example - reset, reboot, cycle
                       default: cycle
-                  wait:
-                      type: Value
+                    - name: wait
                       default: true
                       help: Whether we should wait for the host given the 'rebuild' state was set.
-            - title: host
-              options:
-                  host-address:
-                      type: Value
+              - name: host
+                options:
+                    - name: host-address
                       help: Name or ID of the host as listed in foreman
                       required: yes
-                  host-key:
-                      type: Value
+                    - name: host-key
                       help: "User's SSH key"
                       default: ~/.ssh/id_rsa
-            - title: common
-              options:
-                  dry-run:
-                      action: store_true
-                      help: Only generate settings, skip the playbook execution stage
-                  cleanup:
-                      action: store_true
-                      help: Provision the host using Forman
-                      required: True
-                  input:
-                      action: append
-                      type: str
-                      help: Settings file to be merged first
-                      short: n
-                  output:
-                      type: str
-                      short: o
-                      help: 'Name for the generated settings file (default: stdout)'
-                  extra-vars:
-                      action: append
-                      short: e
-                      help: Extra variables to be merged last
-                      type: str

--- a/settings/provisioner/openstack/openstack.spec
+++ b/settings/provisioner/openstack/openstack.spec
@@ -1,77 +1,44 @@
 ---
-subparsers:
-    openstack:
-        formatter_class: RawTextHelpFormatter
-        help: Provision systems using Ansible OpenStack modules
-        groups:
-            - title: cloud
+command:
+    subcommands:
+        - name: openstack
+          help: Provision systems using Ansible OpenStack modules
+          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
+          groups:
+            - name: cloud
               options:
-                  cloud:
-                      type: Value
+                    - name: cloud
                       help: "The cloud which the OpenStack modules will operate against. Cloud setup instructions: http://docs.openstack.org/developer/os-client-config/#config-files"
                       required: yes
-            - title: prefix
+            - name: prefix
               options:
-                  prefix:
-                      type: Value
+                    - name: prefix
                       help: An prefix which would be contacted to each provisioned resource. An random prefix would be generated in case this value is not specified.
-            - title: keypair details
+            - name: keypair details
               options:
-                  key-file:
-                      type: Value
+                    - name: key-file
                       help: The key file that would be uploaded to nova and injected into VMs upon creation.
                       default: ~/.ssh/id_rsa
-                  key-name:
-                      type: Value
+                    - name: key-name
                       help: The name of the key that would be uploaded to nova and injected into VMs upon creation. If this option is missing, a public key would be generated from the key file and uploaded as a key_pair to the cloud
                       default: ''
-            - title: image
+            - name: image
               options:
-                  image:
-                      type: Value
+                    - name: image
                       help: An image id or name, on OpenStack cloud to provision the instance with. To see full list of images avaialable on the cloud, use 'glance image-list'.
                       required: yes
-            - title: dns
+            - name: dns
               options:
-                  dns:
-                      type: Value
+                    - name: dns
                       help: The dns server the provisioned instances should use.
                       default: 208.67.222.222
-            - title: topology
+            - name: topology
               options:
-                  neutron:
-                      type: YamlFile
+                    - name: neutron
+                      complex_type: YamlFile
                       help: Network resources
                       default: default.yml
-                  nodes:
-                      type: Topology
+                    - name: nodes
+                      complex_type: Topology
                       help: Provision topology.
                       default: "controller:1"
-            - title: common
-              options:
-                  dry-run:
-                      action: store_true
-                      help: Only generate settings, skip the playbook execution stage
-                  cleanup:
-                      action: store_true
-                      help: Clean given system instead of provisioning a new one
-                  input:
-                      action: append
-                      type: str
-                      short: i
-                      help: Input settings file to be loaded before the merging of user args
-                  output:
-                      type: str
-                      short: o
-                      help: 'File to dump the generated settings into (default: stdout)'
-                  extra-vars:
-                      action: append
-                      short: e
-                      help: Extra variables to be merged last
-                      type: str
-                  from-file:
-                      type: IniFile
-                      help: the ini file with the list of arguments
-                  generate-conf-file:
-                      type: str
-                      help: generate configuration file (ini) containing default values and exits. This file is than can be used with the from-file argument

--- a/settings/provisioner/provisioner.spec
+++ b/settings/provisioner/provisioner.spec
@@ -1,6 +1,3 @@
----
-options:
-    inventory:
-        help: 'Inventory file (default: __DEFAULT__)'
-        type: str
-        default: local_hosts
+command:
+    description: Spec to provision systems using different tools
+    include_groups: ['Logging arguments']

--- a/settings/provisioner/virsh/virsh.spec
+++ b/settings/provisioner/virsh/virsh.spec
@@ -1,64 +1,36 @@
 ---
-subparsers:
-    virsh:
-        formatter_class: RawTextHelpFormatter
-        help: Provision systems using virsh
-        groups:
-            - title: Hypervisor
-              options:
-                  host-address:
-                      type: Value
-                      help: Address/FQDN of the BM hypervisor
-                      required: yes
-                  host-user:
-                      type: Value
-                      help: User to SSH to the host with
-                      default: root
-                  host-key:
-                      type: Value
-                      help: "User's SSH key"
-                      default: ~/.ssh/id_rsa
-            - title: image
-              options:
-                  image:
-                      type: YamlFile
-                      help: The image to use for nodes provisioning. Check the 'sample.yml.example' for example.
-                      required: yes
-            - title: topology
-              options:
-                  topology-network:
-                      type: YamlFile
-                      help: Network
-                      default: default.yml
-                  topology-nodes:
-                      type: Topology
-                      help: Provision topology.
-                      default: "undercloud:1,controller:1,compute:1"
-            - title: common
-              options:
-                  dry-run:
-                      action: store_true
-                      help: Only generate settings, skip the playbook execution stage
-                  cleanup:
-                      action: store_true
-                      help: Clean given system instead of provisioning a new one
-                  input:
-                      action: append
-                      type: str
-                      short: i
-                      help: Input settings file to be loaded before the merging of user args
-                  output:
-                      type: str
-                      short: o
-                      help: 'File to dump the generated settings into (default: stdout)'
-                  extra-vars:
-                      action: append
-                      short: e
-                      help: Extra variables to be merged last
-                      type: str
-                  from-file:
-                      type: IniFile
-                      help: the ini file with the list of arguments
-                  generate-conf-file:
-                      type: str
-                      help: generate configuration file (ini) containing default values and exits. This file is than can be used with the from-file argument
+command:
+    subcommands:
+        - name: virsh
+          help: Provision systems using virsh
+          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
+          groups:
+                - name: Hypervisor
+                  options:
+                      - name: host-address
+                        help: Address/FQDN of the BM hypervisor
+                        required: yes
+                      - name: host-user
+                        help: User to SSH to the host with
+                        default: root
+                      - name: host-key
+                        help: "User's SSH key"
+                        default: ~/.ssh/id_rsa
+
+                - name: Image
+                  options:
+                      - name: image
+                        complex_type: YamlFile
+                        help: The image to use for nodes provisioning. Check the 'sample.yml.example' for example.
+                        required: yes
+
+                - name: Topology
+                  options:
+                      - name: topology-network
+                        complex_type: YamlFile
+                        help: Network
+                        default: default.yml
+                      - name: topology-nodes
+                        complex_type: Topology
+                        help: Provision topology.
+                        default: "undercloud:1,controller:1,compute:1"

--- a/tests/integration_tests/test_irspec.py
+++ b/tests/integration_tests/test_irspec.py
@@ -17,7 +17,7 @@ def test_generate_conf_file(conf_file, mock_spec):
     Verify generation of the configuration file.
     """
     mock_spec.run(
-        spec_args=['--req', 'test', '--generate-conf-file=' + conf_file])
+        spec_args=['--req=test', '--generate-conf-file=' + conf_file])
 
     with open(conf_file) as fd:
         config = ConfigParser.ConfigParser()
@@ -33,9 +33,9 @@ def test_generate_conf_file(conf_file, mock_spec):
         # req
         assert config.has_option(mock_spec.IR_SUB_COMMAND, 'req')
         assert config.get(
-            mock_spec.IR_SUB_COMMAND, 'req') == 'Edit with any value, ' \
-                                                'OR override with CLI:' \
-                                                ' --req=<option>'
+            mock_spec.IR_SUB_COMMAND,
+            'req') == 'Required argument. Edit with one of the allowed ' \
+                      'values OR override with CLI: --req=<option>'
         # optional should not be present
         assert not config.has_option(mock_spec.IR_SUB_COMMAND, 'opt ')
 

--- a/tests/specmock.py
+++ b/tests/specmock.py
@@ -20,15 +20,14 @@ class IRMock(object):
         self.config = conf.load_config_file(self.ir_conf_file.strpath)
         self._monkeypatch = monkeypatch
 
-    def run(self, app_args=None, spec_args=None):
+    def run(self, spec_args=None):
         """
         The function to run spec.
         """
-        if app_args is None:
-            app_args = ['-d', '-vvvv']
+
         if spec_args is None:
             spec_args = []
-        argv = ['appmock', ] + app_args + ['cmdmock', ] + spec_args
+        argv = ['appmock', 'cmdmock'] + spec_args
 
         # replace argument by what we want
         self._monkeypatch.setattr(sys, 'argv', argv)
@@ -74,53 +73,55 @@ def mock_settings(mock_roots):
     image_file = app_spec_dir.mkdir('image').join('default.yml')
 
     base_spec_file.write("""---
-options:
-    verbose:
-        help: 'Control Ansible verbosity level'
-        short: v
-        action: count
-        default: 0
-    inventory:
-        help: 'Inventory file'
-        type: str
-        default: local_hosts
-    debug:
-        help: 'Run InfraRed in DEBUG mode'
-        short: d
-        action: store_true
+groups:
+    - name: common
+      options:
+          - name: verbose
+            help: 'Control Ansible verbosity level'
+            short: v
+            action: count
+            default: 0
+          - name: inventory
+            help: 'Inventory file'
+            type: str
+            default: local_hosts
+          - name: debug
+            help: 'Run InfraRed in DEBUG mode'
+            short: d
+            action: store_true
 """)
 
     spec_file.write("""---
-subparsers:
-    cmdmock:
-        formatter_class: RawTextHelpFormatter
-        options:
-            image:
-                type: YamlFile
-                help: test_file
-                default: default.yml
-            opt:
-                type: Value
-                help: optional value
-            req:
-                type: Value
-                help: required value
-                required: yes
-            choice:
-                type: Value
-                help: list of predefined value
-                choices: ["1", "2", "3"]
-                default: 2
-            from-file:
-                type: IniFile
-                help: the ini file with the list of arguments
-            generate-conf-file:
-                type: str
-                help: generate configuration file
-            output:
-                type: str
-                short: o
-                help: 'File to dump the generated settings into'
+command:
+    subcommands:
+        - name: cmdmock
+          include_groups: ['common']
+          groups:
+              - name: test args
+                options:
+                     - name: image
+                       complex_type: YamlFile
+                       help: test_file
+                       default: default.yml
+                     - name: opt
+                       help: optional value
+                     - name: req
+                       help: required value
+                       required: yes
+                     - name: choice
+                       help: list of predefined value
+                       choices: ["1", "2", "3"]
+                       default: 2
+                     - name: from-file
+                       action: read-config
+                       help: reads arguments from file.
+                     - name: generate-conf-file
+                       action: generate-config
+                       help: generate configuration file with default values
+                     - name: output
+                       type: str
+                       short: o
+                       help: 'File to dump the generated settings into'
 """)
     image_file.write("""---
 image_file: file.qcow


### PR DESCRIPTION
Major changes: 

### Separate module to parse args
 * removed clg module dependency. 
 * argparse is still used to parse the cli arguments
 * we also read environment variables and variables form the config (ini) files
 * reading and generation of the config files are now the part of the clg/spec. Added special action for these arguments. 

### Change the spec format

 * now all the spec options should be stored in groups. 
 * global groups of options can be defined. 
 * global gorups can be included into different subcommands.  
 * spec is not more list oriented that dict oriented. "Groups" is now list of dicts. The same is for "subcommands"  

Example for the base spec and global groups 
```
---
groups:
    - name: Logging arguments
      options:
          - name: verbose
            help: 'Control Ansible verbosity level'
            short: v
            action: count
            default: 0
          - name: debug
            help: 'Run InfraRed in DEBUG mode'
            short: d
            action: store_true

    - name: Inventory arguments
      options:
          - name: inventory
            help: 'Inventory file'
            type: str
            default: local_hosts

    - name: Common arguments
      options:
          - name: dry-run
            action: store_true
            help: Only generate settings, skip the playbook execution stage
          - name: cleanup
            action: store_true
            help: Clean given system instead of running playbooks on  a new one
          - name: input
            action: append
            type: str
            short: i
            help: Input settings file to be loaded before the merging of user args
          - name: output
            type: str
            short: o
            help: 'File to dump the generated settings into (default: stdout)'
          - name: extra-vars
            action: append
            short: e
            help: Extra variables to be merged last
            type: str

    - name: Configuration file arguments
      options:
          - name: from-file
            action: read-config
            help: reads arguments from file.
          - name: generate-conf-file
            action: generate-config
            help: generate configuration file with default values
```

Groups can be included into the subcommands (like virsh, ospd or to the ir-provisioner/ir-installer root commands): 

```
---
command:
    subcommands:
        - name: virsh
          help: Provision systems using virsh
          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
          groups:
                - name: Hypervisor
                  options:
                      - name: host-address
                        help: Address/FQDN of the BM hypervisor
                        required: yes
                      - name: host-user
                        help: User to SSH to the host with
                        default: root
                      - name: host-key
                        help: "User's SSH key"
                        default: ~/.ssh/id_rsa
``` 

Command (ir-installler) spec example: 

```
command:
    description: Spec to install OpenStack using different installers
    include_groups: ['Logging arguments']
```

### Changed the resulting structure of the arguments dictionary. 

 * the Spec.parse_args() methods wil return now a dict which is grouped by the subcommands: 

I that exmaple we have "root" dict with argument for ir-provisioner and 'virsh' for the virsh related arguments. All the YamlFile arguments are resolved to the dicts. 
```
{'root': {'command0': 'virsh', 'debug': False, 'verbose': 0},
 'virsh': {'cleanup': False,
           'dry-run': True,
           'host-address': 'jupiter',
           'host-key': '~/key.pem',
           'host-user': '12345',
           'image': {'file': 'Image_file.qcow',
                     'server': 'http://images/'},
           'inventory': 'local_hosts',
           'topology-network': {...},
           'topology-nodes': {...}}
}
```

### Changed arguments types structure

 * type: Value is not longer required
 * added new keyword "complex_type" to describe Topology, YamfFile types. 
 * removed logic to resolve the values from the types. Now types are mach simplier and only responsible to read values. 

Example for the complex_types in spec: 

```
---
command:
    subcommands:
        - name: ospd
          help: Installs openstack using OSP Director
          include_groups: ['Inventory arguments', 'Common arguments', 'Configuration file arguments']
          groups:
            - name: Firewall
              options:
                  - name: firewall
                    complex_type: YamlFile
                    help: The firewall configuration
                    default: default.yml

```

### Arguments validation
 * Added more validation for arguments
 * If argument was not provided with cli, we print now the source of argument
 * required arguments validation

Output from infrared when there are no required arguments:
```
$ ir-provisioner virsh 
   
WARNING Configuration file not found, using InfraRed project dir
WARNING [virsh] Argument 'dry-run' was set to 'False' from the spec defaults source.
WARNING [virsh] Argument 'host-user' was set to 'root' from the spec defaults source.
WARNING [virsh] Argument 'cleanup' was set to 'False' from the spec defaults source.
WARNING [virsh] Argument 'host-key' was set to '~/.ssh/id_rsa' from the spec defaults source.
WARNING [virsh] Argument 'inventory' was set to 'local_hosts' from the spec defaults source.
WARNING [virsh] Argument 'topology-nodes' was set to 'undercloud:1,controller:1,compute:1' from the spec defaults source.
WARNING [virsh] Argument 'topology-network' was set to 'default.yml' from the spec defaults source.
WARNING [root] Argument 'debug' was set to 'False' from the spec defaults source.
WARNING [root] Argument 'verbose' was set to '0' from the spec defaults source.
ERROR   Required argument 'host-address' is not set for 'virsh' command
ERROR   Required argument 'image' is not set for 'virsh' command
WARNING Received arguments for 'virsh' command: {'dry-run': False, 'host-user': 'root', 'cleanup': False, 'host-key': '~/.ssh/id_rsa', 'inventory': 'local_hosts', 'topology-nodes': 'undercloud:1,controller:1,compute:1', 'topology-network': 'default.yml'}

```

DIfferent arguments source indication (config file, env. variable, spec): 

```
$ ir-provisioner virsh --from-file=virsh.ini --host-address=jupiter --dry-run

WARNING Configuration file not found, using InfraRed project dir
WARNING [virsh] Argument 'topology-nodes' was set to '1_controller,1_compute,1_undercloud,1_ceph' from the config file source.
WARNING [virsh] Argument 'topology-network' was set to 'default.yml' from the config file source.
WARNING [virsh] Argument 'host-key' was set to '~/.ssh/key.pem' from the config file source.
WARNING [virsh] Argument 'image' was set to 'image.yml' from the config file source.
WARNING [virsh] Argument 'cleanup' was set to 'False' from the spec defaults source.
WARNING [virsh] Argument 'inventory' was set to 'local_hosts' from the spec defaults source.
WARNING [virsh] Argument 'host-user' was set to 'root' from the spec defaults source.
WARNING [root] Argument 'debug' was set to 'False' from the spec defaults source.
WARNING [root] Argument 'verbose' was set to '0' from the spec defaults source.
```

All the command arguments left as they were before. No changes are required in jobs invocation. 