### PR TITLE
Removes fingerprint of host from known_host

### DIFF
--- a/playbooks/provisioner/beaker/main.yml
+++ b/playbooks/provisioner/beaker/main.yml
@@ -47,6 +47,12 @@
       when: provisioner.ssh_key is defined
       delegate_to: localhost
 
+    - name: Remove provisioned hosts from known_hosts
+      known_hosts:
+        name: "{{ inventory_hostname }}"
+        state: absent
+      delegate_to: localhost
+
     - name: Copy SSH key to authorized_key
       authorized_key:
         key: "{{ cmd_reg.stdout }}"


### PR DESCRIPTION
Adds a task to the Beaker main playbook which removes the fingerprint
of host provisioned with Beaker from the known_hosts file