### PR TITLE
[OSPD] Adds support to fetch images from RPM

### DIFF
--- a/roles/installer/ospd/images/defaults/main.yml
+++ b/roles/installer/ospd/images/defaults/main.yml
@@ -7,4 +7,4 @@ tar_files:
         - "ironic-python-agent.tar"
         - "overcloud-full.tar"
 
-tar_images: "{{ installer.images.files | default(tar_files[installer.product.version]) }}"
+tar_images: "{{ installer.images.files | default(tar_files[installer.product.version|string]) }}"

--- a/roles/installer/ospd/images/tasks/rpm.yml
+++ b/roles/installer/ospd/images/tasks/rpm.yml
@@ -1,0 +1,21 @@
+---
+- name: install the RPM with the pre-built overcloud images
+  become: yes
+  yum:
+      name: "rhosp-director-images"
+      state: present
+
+- name: move images (sym link) to home dir
+  become: yes
+  shell: "cp /usr/share/rhosp-director-images/{{ item }} ~/{{ item }}"
+  with_items: "{{ tar_images }}"
+
+- name: untar the images
+  become: yes
+  unarchive:
+      src: "~/{{ item }}"
+      dest: "~/"
+      copy: "no"
+      owner: "{{ installer.user.name }}"
+      group: "{{ installer.user.name }}"
+  with_items: "{{ tar_images }}"

--- a/settings/installer/ospd/ospd.spec
+++ b/settings/installer/ospd/ospd.spec
@@ -57,9 +57,13 @@ subparsers:
               options:
                 images-task:
                     type: Value
-                    help: Specifies whether the images should be built or imported
-                    required: yes
-                    choices: [import, build]
+                    help: |
+                        Specifies the source for the OverCloud images:
+                        * RPM - packaged with product (versions 8 and above)
+                        * IMPORT - fetch from external source (versions 7 and 8). Requires to specify '--image-url'.
+                        * BUILD - build images locally (takes longer)
+                    choices: [import, build, rpm]
+                    default: rpm
                 images-url:
                     type: Value
                     help: Specifies the import image url. Required only when images task is 'import'


### PR DESCRIPTION
Started in OSPD 9 (and backported to 8), overcloud images are packaged
with product RPM.

Also requires some casting of arguments from int values to string.