### PR TITLE
Change overcloud VMs name to start at index 0

### DIFF
--- a/playbooks/installer/ospd/templates/virthost_instack.json.j2
+++ b/playbooks/installer/ospd/templates/virthost_instack.json.j2
@@ -12,9 +12,9 @@
       "pm_password": "$(cat ~/.ssh/id_rsa)",
       "pm_type": "pxe_ssh",
       "mac": ["{{ hostvars[host_name]['ansible_%s' % installer.undercloud.config.local_interface].macaddress }}"],
-      "cpu": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890')].cpu }}",
-      "memory": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890')].memory }}",
-      "disk": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890')].disks.disk1.size | regex_replace('(?P<size>[0-9]+).*$', '\\g<size>') }}",
+      "cpu": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890-')].cpu }}",
+      "memory": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890-')].memory }}",
+      "disk": "{{ provisioner.topology.nodes[host_name.rstrip('1234567890-')].disks.disk1.size | regex_replace('(?P<size>[0-9]+).*$', '\\g<size>') }}",
       "arch": "x86_64",
       "pm_user": "{{ installer.user.name }}"
     }{% if not loop.last %},{% endif %}

--- a/roles/installer/ospd/overcloud/tagging/tasks/main.yml
+++ b/roles/installer/ospd/overcloud/tagging/tasks/main.yml
@@ -9,7 +9,7 @@
   shell: "source ~/stackrc; openstack flavor set --property 'cpu_arch'='x86_64' --property 'capabilities:boot_option'='local' baremetal"
 
 - name: create the flavors for our machines
-  shell: "source ~/stackrc; openstack flavor create --id auto --ram {{ hostvars[item].ansible_memtotal_mb }} --disk {{ hostvars[item].ansible_devices.vda.size | regex_replace('^([0-9]+).*$', '\\1') | int - 5 }} --vcpus {{ hostvars[item].ansible_processor_vcpus | int - 1 }} {{ item.rstrip('1234567890') }}-{{ item.rstrip('1234567890') | to_uuid }}"
+  shell: "source ~/stackrc; openstack flavor create --id auto --ram {{ hostvars[item].ansible_memtotal_mb }} --disk {{ hostvars[item].ansible_devices.vda.size | regex_replace('^([0-9]+).*$', '\\1') | int - 5 }} --vcpus {{ hostvars[item].ansible_processor_vcpus | int - 1 }} {{ item.rstrip('1234567890-') }}-{{ item.rstrip('1234567890-') | to_uuid }}"
   register: flavor_result
   failed_when: "result.rc != 0 and result.stderr.find('Flavor with name {{ item }}-{{ item | to_uuid }} already exists') != -1"
   with_items: "{{ groups['overcloud_nodes'] }}"
@@ -29,7 +29,7 @@
 
 - name: tag our nodes with the proper profile
   shell: "source ~/stackrc; ironic node-update {{ item[0].stdout }} add properties/capabilities='profile:{{ item[1].cmd.split() | last }},boot_option:local'"
-  when: "item[0].item is defined and item[1].cmd is defined and item[0].item.rstrip('1234567890') in item[1].cmd"
+  when: "item[0].item is defined and item[1].cmd is defined and item[0].item.rstrip('1234567890-') in item[1].cmd"
   with_nested:
       - "{{ node_list.results }}"
       - "{{ tagged_flavors }}"

--- a/roles/provisioner/virsh/tasks/main.yml
+++ b/roles/provisioner/virsh/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: add hosts to host list
   add_host:
       name="{{ item.item.item[0] }}"
-      groups="{{ provisioner.topology.nodes['%s' % item.item.item[0].rstrip('1234567890')].groups | join(',') }}"
+      groups="{{ provisioner.topology.nodes['%s' % item.item.item[0].rstrip('1234567890-')].groups | join(',') }}"
       ansible_ssh_user="root"
       ansible_ssh_pass="redhat"
       ansible_ssh_host="{{ item.stdout }}"

--- a/roles/provisioner/virsh/templates/create_disks.sh.j2
+++ b/roles/provisioner/virsh/templates/create_disks.sh.j2
@@ -1,10 +1,19 @@
 #!/bin/bash
 
 {% for node_name, node_values in provisioner.topology.nodes.iteritems() %}
+{% if 'overcloud_nodes' in node_values.groups %}
+{% for num in range(0, node_values.amount, 1) %}
+{% for disk_name, disk_values in node_values.disks.iteritems() %}
+qemu-img create -f qcow2 {{ disk_values.path }}/{{ node_name }}-{{ num }}.{{ disk_name }}.qcow2 {{ disk_values.size }}
+{% endfor %}
+virt-resize --expand /dev/sda1 /var/lib/libvirt/images/base_image.qcow2 {{ node_values.disks.disk1.path }}/{{ node_name }}-{{ num }}.disk1.qcow2
+{% endfor %}
+{% else %}
 {% for num in range(1, node_values.amount + 1, 1) %}
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
 qemu-img create -f qcow2 {{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2 {{ disk_values.size }}
 {% endfor %}
 virt-resize --expand /dev/sda1 /var/lib/libvirt/images/base_image.qcow2 {{ node_values.disks.disk1.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.disk1.qcow2
 {% endfor %}
+{% endif %}
 {% endfor %}

--- a/roles/provisioner/virsh/templates/create_vms.sh.j2
+++ b/roles/provisioner/virsh/templates/create_vms.sh.j2
@@ -1,9 +1,10 @@
 #!/bin/bash
 {% for node_name, node_values in provisioner.topology.nodes.iteritems() %}
-{% for num in range(1, node_values.amount + 1, 1) %}
-virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %} \
+{% if 'overcloud_nodes' in node_values.groups %}
+{% for num in range(0, node_values.amount, 1) %}
+virt-install --name {{ node_name }}-{{ num }} \
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
-             --disk path={{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2 \
+             --disk path={{ disk_values.path }}/{{ node_name }}-{{ num }}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2 \
 {% endfor %}
 {#{%  for net in provisioner.topology.network.keys() %}#}
 {#    todo(yfried): make network order work#}
@@ -25,4 +26,31 @@ virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% en
              --autostart \
              --vnc
 {% endfor %}
+{% else %}
+{% for num in range(1, node_values.amount + 1, 1) %}
+virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %} \
+{% for disk_name, disk_values in node_values.disks.iteritems() %}
+             --disk path={{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2 \
+{% endfor %}
+{% endfor %}
+{#{%  for net in provisioner.topology.network.keys() %}#}
+{#    todo(yfried): make network order work#}
+{#             --network network:{{ net }} \#}
+{#{% endfor %}#}
+{# Hard coding network names because undercloud needs "data" network to map
+ to the NIC defined in ospd.yml::installer.undercloud.config.local_interface
+    todo(yfried): remove hardcoded network names#}
+            --network network:data \
+            --network network:management \
+            --network network:external \
+             --virt-type kvm \
+             --cpu host-model \
+             --ram {{ node_values.memory }} \
+             --vcpus {{ node_values.cpu }} \
+             --os-variant {{ node_values.os.variant }} \
+             --import \
+             --noautoconsole \
+             --autostart \
+             --vnc
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
This change enables the creation of overcloud VMs by using an index starting at 0 in the form of <role>-<index>

It addresses issue #229