### PR TITLE
Enable virsh VMs disks preallocation and cache options

### DIFF
--- a/roles/provisioner/virsh/templates/create_disks.sh.j2
+++ b/roles/provisioner/virsh/templates/create_disks.sh.j2
@@ -3,7 +3,7 @@
 {% for node_name, node_values in provisioner.topology.nodes.iteritems() %}
 {% for num in range(1, node_values.amount + 1, 1) %}
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
-qemu-img create -f qcow2 {{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2 {{ disk_values.size }}
+qemu-img create -f qcow2 -o preallocation={{ disk_values.preallocation }} {{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2 {{ disk_values.size }}
 {% endfor %}
 virt-resize --expand /dev/sda1 /var/lib/libvirt/images/base_image.qcow2 {{ node_values.disks.disk1.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.disk1.qcow2
 {% endfor %}

--- a/roles/provisioner/virsh/templates/create_vms.sh.j2
+++ b/roles/provisioner/virsh/templates/create_vms.sh.j2
@@ -3,7 +3,7 @@
 {% for num in range(1, node_values.amount + 1, 1) %}
 virt-install --name {{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %} \
 {% for disk_name, disk_values in node_values.disks.iteritems() %}
-             --disk path={{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2 \
+             --disk path={{ disk_values.path }}/{{ node_name }}{% if node_values.amount > 1 %}{{ num }}{% endif %}.{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2,cache={{ disk_values.cache }} \
 {% endfor %}
 {#{%  for net in provisioner.topology.network.keys() %}#}
 {#    todo(yfried): make network order work#}

--- a/settings/provisioner/topology/ceph.yml
+++ b/settings/provisioner/topology/ceph.yml
@@ -10,10 +10,14 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "20G"
+        cache: "default"
+        preallocation: "metadata"
     disk2:
         <<: *disk1
         dev: /dev/vdb
         size: "40G"
+        cache: "default"
+        preallocation: "metadata"
 network:
     interfaces:
         management:

--- a/settings/provisioner/topology/compute.yml
+++ b/settings/provisioner/topology/compute.yml
@@ -10,6 +10,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "40G"
+        cache: "default"
+        preallocation: "metadata"
 network:
     interfaces:
         management:

--- a/settings/provisioner/topology/controller.yml
+++ b/settings/provisioner/topology/controller.yml
@@ -10,6 +10,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "40G"
+        cache: "default"
+        preallocation: "metadata"
 network:
     interfaces:
         management:

--- a/settings/provisioner/topology/loadbalancer.yml
+++ b/settings/provisioner/topology/loadbalancer.yml
@@ -9,6 +9,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "20G"
+        cache: "default"
+        preallocation: "metadata"
 groups:
     - loadbalancer
 

--- a/settings/provisioner/topology/swift.yml
+++ b/settings/provisioner/topology/swift.yml
@@ -10,6 +10,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "20G"
+        cache: "default"
+        preallocation: "metadata"
 
 network:
     interfaces:

--- a/settings/provisioner/topology/tester.yml
+++ b/settings/provisioner/topology/tester.yml
@@ -10,6 +10,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "30G"
+        cache: "default"
+        preallocation: "metadata"
 network:
     interfaces:
         management:

--- a/settings/provisioner/topology/undercloud.yml
+++ b/settings/provisioner/topology/undercloud.yml
@@ -10,6 +10,8 @@ disks:
         path: "/var/lib/libvirt/images"
         dev: "/dev/vda"
         size: "40G"
+        cache: "default"
+        preallocation: "metadata"
 network:
     interfaces:
         management:


### PR DESCRIPTION
This change introduces the ability to specify the preallocation
option to the qemu-img command which creates the virsh VMs disks.
It also enables the ability to specify the libvirt disk cache mode.

These options are useful when the user wants to tune the disks
parameters.

Parameters references:
https://rwmj.wordpress.com/2013/09/02/new-in-libguestfs-allow-cache-mode-to-be-selected/
https://kashyapc.com/2011/12/02/little-more-disk-io-perf-improvement-with-fallocateing-a-qcow2-disk/
https://libvirt.org/formatdomain.html