### PR TITLE
HOTFIX dict insert

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -29,7 +29,7 @@ def dict_insert(dic, val, key, *keys):
         return
 
     if not keys:
-        if key in dic and isinstance(val, dict):
+        if isinstance(dic.get(key, None), dict) and isinstance(val, dict):
             dict_merge(dic[key], val)
         else:
             dic[key] = val


### PR DESCRIPTION
```yaml
dict:
  k1:
    k2: "string"
```

dict_insert(dict, some_dict_val, k1.k2)

Trying to insert a dict value to a place where none-dict value exists
would invoke dict merge with (none-dict, dict) input resulting in error.

Solution: only invoke dict_merge if both items are dict. otherwise,
overwrite none-dict value.