### PR TITLE
Avoid files bigger than 1GB be added in the collect logs tarball

### DIFF
--- a/playbooks/collect-logs.yml
+++ b/playbooks/collect-logs.yml
@@ -136,7 +136,7 @@
     - name: collect logs
       shell: |
         mkdir -p /tmp/{{ inventory_hostname }};
-        find {{ job.archive|join(' ') }} -maxdepth 2 -type f -size -1024M -not -path '*/\.*' -exec cp -rL --parents {} /tmp/{{ inventory_hostname }} \;
+        find /var/log/rpm.list /var/log/extra {{ job.archive|join(' ') }} -maxdepth 2 -type f -size -1024M -not -path '*/\.*' -exec cp -rL --parents {} /tmp/{{ inventory_hostname }} \;
         find /tmp/{{ inventory_hostname }} -type d -print0 | xargs -0 chmod 755;
         find /tmp/{{ inventory_hostname }} -type f -print0 | xargs -0 chmod 644;
       ignore_errors: true

--- a/playbooks/collect-logs.yml
+++ b/playbooks/collect-logs.yml
@@ -136,9 +136,7 @@
     - name: collect logs
       shell: |
         mkdir -p /tmp/{{ inventory_hostname }};
-        for F in $(ls -d1 /var/log/rpm.list /var/log/extra {{ job.archive|join(' ') }}); do
-          cp -rL --parents $F /tmp/{{ inventory_hostname }}
-        done;
+        find {{ job.archive|join(' ') }} -maxdepth 2 -type f -size -1024M -not -path '*/\.*' -exec cp -rL --parents {} /tmp/{{ inventory_hostname }} \;
         find /tmp/{{ inventory_hostname }} -type d -print0 | xargs -0 chmod 755;
         find /tmp/{{ inventory_hostname }} -type f -print0 | xargs -0 chmod 644;
       ignore_errors: true


### PR DESCRIPTION
This is necessary in case we are building images and since these images
have usually more than 10GB, when we collect the logs, the tarball
became huge unecessary.