### PR TITLE
Fix broken handling of rhos-release

### DIFF
--- a/playbooks/installer/ospd/virthost.yml
+++ b/playbooks/installer/ospd/virthost.yml
@@ -31,10 +31,10 @@
         delay: 5
 
       - debug:
-            msg: "rhos-release {{ installer.product.core.version }}-director -p {{ installer.product.core.build }}"
+            msg: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
 
       - name: create necessary repos for core using rhos-release
-        command: "rhos-release {{ installer.product.core.version }}-director -p {{ installer.product.core.build }}"
+        command: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
         register: command_result
         until: command_result.stderr.find('Connection reset by peer') == -1
         retries: 40

--- a/roles/installer/ospd/undercloud/tasks/setup.yml
+++ b/roles/installer/ospd/undercloud/tasks/setup.yml
@@ -25,10 +25,10 @@
   delay: 5
 
 - debug:
-      msg: "rhos-release {{ installer.product.core.version }}-director -p {{ installer.product.core.build }}"
+      msg: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
 
 - name: create necessary repos for core using rhos-release
-  command: "rhos-release {{ installer.product.core.version }}-director -p {{ installer.product.core.build }}"
+  command: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
   register: command_result
   until: command_result.stderr.find('Connection reset by peer') == -1
   retries: 40


### PR DESCRIPTION
Rhos-release tool is not maintaining dependencies
between ospd and core versions properly when "latest"
is not specified. Therefore ability to specify certain
version numbers must be working (until this broken) and called
in specific order. First, we need to call rhos-release with
{{ installer.product.version }}-director and version number
and then {{ installer.product.core.version }} with different
specific core version number. Otherwise, rhos-release end up
in creating repositories with links to non-existing repos
and deployment will fail.

This fixes issues 171 and 256.