### PR TITLE
Correct usage of rhos-release to always pin

### DIFF
--- a/playbooks/installer/ospd/virthost.yml
+++ b/playbooks/installer/ospd/virthost.yml
@@ -21,20 +21,20 @@
         shell: "rhos-release -x"
 
       - debug:
-            msg: "rhos-release {{ installer.product.version }}-director -p {{ installer.product.build }}"
+            msg: "rhos-release {{ installer.product.version }}-director -P -p {{ installer.product.build }}"
 
       - name: create necessary repos with for director using rhos-release
-        command: "rhos-release {{ installer.product.version }}-director -p {{ installer.product.build }}"
+        command: "rhos-release {{ installer.product.version }}-director -P -p {{ installer.product.build }}"
         register: command_result
         until: command_result.stderr.find('Connection reset by peer') == -1
         retries: 40
         delay: 5
 
       - debug:
-            msg: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
+            msg: "rhos-release {{ installer.product.core.version }} -P -p {{ installer.product.core.build }}"
 
       - name: create necessary repos for core using rhos-release
-        command: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
+        command: "rhos-release {{ installer.product.core.version }} -P -p {{ installer.product.core.build }}"
         register: command_result
         until: command_result.stderr.find('Connection reset by peer') == -1
         retries: 40

--- a/roles/installer/ospd/undercloud/tasks/setup.yml
+++ b/roles/installer/ospd/undercloud/tasks/setup.yml
@@ -22,20 +22,20 @@
   shell: "yum localinstall -y {{ installer.product.rpm }}"
 
 - debug:
-      msg: "rhos-release {{ installer.product.version }}-director -p {{ installer.product.build }}"
+      msg: "rhos-release {{ installer.product.version }}-director -P -p {{ installer.product.build }}"
 
 - name: create necessary repos with for director using rhos-release
-  command: "rhos-release {{ installer.product.version }}-director -p {{ installer.product.build }}"
+  command: "rhos-release {{ installer.product.version }}-director -P -p {{ installer.product.build }}"
   register: command_result
   until: command_result.stderr.find('Connection reset by peer') == -1
   retries: 40
   delay: 5
 
 - debug:
-      msg: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
+      msg: "rhos-release {{ installer.product.core.version }} -P -p {{ installer.product.core.build }}"
 
 - name: create necessary repos for core using rhos-release
-  command: "rhos-release {{ installer.product.core.version }} -p {{ installer.product.core.build }}"
+  command: "rhos-release {{ installer.product.core.version }} -P -p {{ installer.product.core.build }}"
   register: command_result
   until: command_result.stderr.find('Connection reset by peer') == -1
   retries: 40

--- a/roles/installer/packstack/repo/tasks/main.yml
+++ b/roles/installer/packstack/repo/tasks/main.yml
@@ -9,7 +9,7 @@
   command: "yum localinstall -y {{ installer.product.rpm }}"
 
 - name: Execute rhos-release for packstack poodle/puddle
-  command: "rhos-release {{ installer.product.version }} -p {{ installer.product.build }}"
+  command: "rhos-release {{ installer.product.version }} -P -p {{ installer.product.build }}"
 
 - name: repolist
   command: yum -d 7 repolist

--- a/roles/loadbalancer/tasks/main.yml
+++ b/roles/loadbalancer/tasks/main.yml
@@ -61,7 +61,7 @@
   command: "yum localinstall -y {{ installer.product.rpm }}"
 
 - name: Execute rhos-release for OSP-Director
-  command: rhos-release {{ installer.product.version }}
+  command: rhos-release -P {{ installer.product.version }}
 
 - name: update all packages
   yum: name=* state=latest


### PR DESCRIPTION
include -P to pin all versions installed and not point at latest
This prevents the repo from shifting if a new version comes out
while a test is underway

Change-Id: I699092949f09c16247f7e7f032dd0afa3fab40c3