### PR TITLE
py3 compatibility fixes

### DIFF
--- a/cli/clg.py
+++ b/cli/clg.py
@@ -5,7 +5,10 @@ according to the specification (spec) files.
 
 import argparse
 import collections
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import glob
 import os
 import re

--- a/cli/conf.py
+++ b/cli/conf.py
@@ -1,6 +1,8 @@
-import ConfigParser
-
-import exceptions
+try:
+    import ConfigParser
+    import exceptions
+except ImportError:
+    import configparser as ConfigParser
 import os
 
 from cli import utils

--- a/cli/execute.py
+++ b/cli/execute.py
@@ -58,7 +58,7 @@ def _run_playbook(cli_args, settings):
     """
     with tempfile.NamedTemporaryFile(
             prefix="ir-settings-", delete=True) as tmp:
-        tmp.write(yaml.safe_dump(settings, default_flow_style=False))
+        tmp.write(yaml.safe_dump(settings, default_flow_style=False).encode('utf-8'))
         # make sure ansible can read that file.
         tmp.flush()
         cli_args.extend(['--extra-vars', "@" + tmp.name])

--- a/cli/main.py
+++ b/cli/main.py
@@ -200,7 +200,7 @@ class IRSpec(object):
             with open(dump_file, 'w') as output_file:
                 output_file.write(output)
         else:
-            print output
+            print(output)
 
 
 def main(spec_name):

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -114,7 +114,7 @@ def search_tree(needle, haystack, _res=None):
         _res = []
     if needle in haystack:
         _res.append(haystack[needle])
-    for key, value in haystack.iteritems():
+    for key, value in haystack.items():
         if isinstance(value, dict):
             search_tree(needle, value, _res)
         if isinstance(value, list):

--- a/cli/yamls.py
+++ b/cli/yamls.py
@@ -103,10 +103,10 @@ def replace_lookup(lookups_dict):
     """
     def yaml_walk(yaml_content, key_path=None):
         an_iter = enumerate(yaml_content) if isinstance(yaml_content, list) \
-            else yaml_content.iteritems()
+            else yaml_content.items()
 
         for idx_key, value in an_iter:
-            if hasattr(value, '__iter__'):
+            if hasattr(value, '__iter__') and not isinstance(value, str):
                 if key_path is None:
                     next_key = str(idx_key)
                 else:

--- a/library/beaker_provisioner.py
+++ b/library/beaker_provisioner.py
@@ -164,7 +164,7 @@ class BeakerMachine(object):
         params = dict(tg_format='atom', list_tgp_limit=limit)
 
         cnt = 0
-        for f_name, f_val in filters.iteritems():
+        for f_name, f_val in filters.items():
             params['systemsearch-{0}.table'.format(cnt)] = f_name
             params['systemsearch-{0}.operation'.format(cnt)] = 'is'
             params['systemsearch-{0}.value'.format(cnt)] = f_val

--- a/playbooks/provisioner/templates/ifcfg-interface.j2
+++ b/playbooks/provisioner/templates/ifcfg-interface.j2
@@ -1,6 +1,6 @@
 #jinja2: trim_blocks: False
 {%- if item.value.config_params is defined -%}
-{%- for key, value in item.value.config_params.iteritems() %}
+{%- for key, value in item.value.config_params.items() %}
 {{ key|upper }}={{ value }}
 {%- endfor %}
 {%- endif -%}

--- a/roles/installer/ospd/overcloud/hostname/templates/hostnames.yml.j2
+++ b/roles/installer/ospd/overcloud/hostname/templates/hostnames.yml.j2
@@ -5,7 +5,7 @@
 
 parameter_defaults:
 {% if installer.scheduler_hints|default(False) %}
-{% for node_type, details in node_types.iteritems() %}
+{% for node_type, details in node_types.items() %}
 {% if groups[node_type]|default([])|length %}
     {{ details.heat_name }}SchedulerHints:
         'capabilities:node': '{{ node_type }}-%index%'
@@ -13,13 +13,13 @@ parameter_defaults:
 {% endfor %}
 {% endif %}
 
-{% for node_type, details in node_types.iteritems() %}
+{% for node_type, details in node_types.items() %}
     {{ details.heat_name }}HostnameFormat: '{{ node_type }}-%index%'
 {% endfor %}
 
 {% if installer.get("overcloud", {}).get("hostname", {}).get("HostnameMap", false) %}
     HostnameMap:
-{% for old_name, new_name in installer.overcloud.hostname.HostnameMap.iteritems() %}
+{% for old_name, new_name in installer.overcloud.hostname.HostnameMap.items() %}
         {{ old_name }}: {{ new_name }}
 {% endfor %}
 {% endif %}

--- a/roles/provisioner/virsh/tasks/vms_1_create_disk.yml
+++ b/roles/provisioner/virsh/tasks/vms_1_create_disk.yml
@@ -3,7 +3,7 @@
 - name: create disk(s) from vm base image
   shell: |
       {% for num in range(1, item.value.amount + 1, 1) %}
-      {% for disk_name, disk_values in item.value.disks.iteritems() %}
+      {% for disk_name, disk_values in item.value.disks.items() %}
       {% set node_image = '{0}-{1}-{2}.qcow2'.format(item.value.name, num - 1, disk_name) %}
       {% if not disk_values.import_url %}
 

--- a/roles/provisioner/virsh/tasks/vms_2_install.yml
+++ b/roles/provisioner/virsh/tasks/vms_2_install.yml
@@ -4,7 +4,7 @@
   shell: |
 
           virt-install --name {{ node.value.name }}-{{ item }} \
-            {% for disk_name, disk_values in node.value.disks.iteritems() %}
+            {% for disk_name, disk_values in node.value.disks.items() %}
             {% if disk_values.import_url is defined and disk_values.import_url %}
              --disk path={{ base_image_path }}/{{ node.value.name }}-{{ item }}-{{ disk_name }}.qcow2,device=disk,bus=virtio,format=qcow2,cache={{ disk_values.cache }} \
             {% else %}

--- a/tests/integration_tests/test_irspec.py
+++ b/tests/integration_tests/test_irspec.py
@@ -1,6 +1,8 @@
 # holds the integration tests for IRSpec
-import ConfigParser
-
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import os
 import yaml
 import pytest

--- a/tests/test_cwd/utils.py
+++ b/tests/test_cwd/utils.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-import utils
+from cli import utils
 
 TESTS_CWD = os.path.dirname(__file__)
 SETTINGS_PATH = os.path.join(TESTS_CWD, "settings")


### PR DESCRIPTION
These changes are adding support for Python 3 while keeping the code backwards compatible.

Note: the tests are not passing yet on py3 because Ansible does not work on py3 yet. Still, this is solving infrared specific py3 issues.