### PR TITLE
OSPD: Changes default ver of product-core-version

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -44,7 +44,7 @@
       rr_rpm_url: "{{ installer.product.rpm }}"
       director_version: "{{ installer.product.version }}"
       director_build: "{{ installer.product.build }}"
-      core_version: "{{ installer.product.core.version }}"
+      core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
       core_build: "{{ installer.product.core.build }}"
       mirror: "{{ installer.mirror | default(omit) }}"
       when: groups.loadbalancer is defined

--- a/playbooks/installer/ospd/main.yml
+++ b/playbooks/installer/ospd/main.yml
@@ -12,7 +12,7 @@
         rr_rpm_url: "{{ installer.product.rpm }}"
         director_version: "{{ installer.product.version }}"
         director_build: "{{ installer.product.build }}"
-        core_version: "{{ installer.product.core.version }}"
+        core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
         core_build: "{{ installer.product.core.build }}"
         rr_distro_version: "{{ hostvars[groups.undercloud[0]].ansible_distribution_version }}"
         mirror: "{{ installer.mirror | default(omit) }}"

--- a/playbooks/installer/ospd/post_install/add_nodes_to_ironic_list.yml
+++ b/playbooks/installer/ospd/post_install/add_nodes_to_ironic_list.yml
@@ -86,7 +86,7 @@
         rr_rpm_url: "{{ installer.product.rpm }}"
         director_version: "{{ installer.product.version }}"
         director_build: "{{ installer.product.build }}"
-        core_version: "{{ installer.product.core.version }}"
+        core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
         core_build: "{{ installer.product.core.build }}"
         rr_distro_version: "{{ hostvars[groups.undercloud[0]].ansible_distribution_version }}"
         mirror: "{{ installer.mirror | default(omit) }}"

--- a/playbooks/installer/ospd/undercloud-backup.yml
+++ b/playbooks/installer/ospd/undercloud-backup.yml
@@ -31,7 +31,7 @@
             mode: "0400"
 
       - name: copy our image to the backup server
-        shell: "scp -o StrictHostKeyChecking=no -i ~/backup_server_auth_key {{ undercloud_image_file }} {{ private.storage.oc_image_repo.user }}@{{ private.storage.oc_image_repo.server }}:{{ private.storage.oc_image_repo.path }}/{{ installer.product.core.version }}/{{ undercloud_image_file }}"
+        shell: "scp -o StrictHostKeyChecking=no -i ~/backup_server_auth_key {{ undercloud_image_file }} {{ private.storage.oc_image_repo.user }}@{{ private.storage.oc_image_repo.server }}:{{ private.storage.oc_image_repo.path }}/{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}/{{ undercloud_image_file }}"
 
       # TODO(yfried): this should be in block/allways so cleanup is executed regardless of previous tasks
       - name: cleanup our files

--- a/playbooks/installer/ospd/undercloud-restore.yml
+++ b/playbooks/installer/ospd/undercloud-restore.yml
@@ -19,7 +19,7 @@
         rr_rpm_url: "{{ installer.product.rpm }}"
         director_version: "{{ installer.product.version }}"
         director_build: "{{ installer.product.build }}"
-        core_version: "{{ installer.product.core.version }}"
+        core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
         core_build: "{{ installer.product.core.build }}"
         mirror: "{{ installer.mirror | default(omit) }}"
   tasks:

--- a/playbooks/installer/ospd/virthost.yml
+++ b/playbooks/installer/ospd/virthost.yml
@@ -8,7 +8,7 @@
         rr_rpm_url: "{{ installer.product.rpm }}"
         director_version: "{{ installer.product.version }}"
         director_build: "{{ installer.product.build }}"
-        core_version: "{{ installer.product.core.version }}"
+        core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
         core_build: "{{ installer.product.core.build }}"
         rr_distro_version: "{% if installer.product.version|int < 10 %}7.2{% else %}7.3{% endif %}"
         mirror: "{{ installer.mirror | default(omit) }}"

--- a/roles/installer/ospd/images/tasks/build.yml
+++ b/roles/installer/ospd/images/tasks/build.yml
@@ -17,7 +17,7 @@
   shell: "source ~/stackrc; openstack overcloud image build --all > openstack-build-images.log"
   environment:
       DIB_LOCAL_IMAGE: "/home/{{ installer.user.name }}/base_image.qcow2"
-      DIB_YUM_REPO_CONF: "/etc/yum.repos.d/rhos-release-{{ installer.product.version }}-director.repo /etc/yum.repos.d/rhos-release-{{ installer.product.core.version }}.repo /etc/yum.repos.d/rhos-release-{{ ansible_product_version.split() | first | lower }}-{{ ansible_distribution_version }}.repo"
+      DIB_YUM_REPO_CONF: "/etc/yum.repos.d/rhos-release-{{ installer.product.version }}-director.repo /etc/yum.repos.d/rhos-release-{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}.repo /etc/yum.repos.d/rhos-release-{{ ansible_product_version.split() | first | lower }}-{{ ansible_distribution_version }}.repo"
       NODE_DIST: "rhel7"
       RHOS: 1
       RUN_RHOS_RELEASE: 1

--- a/roles/installer/ospd/images/tasks/update_overcloud_images.yml
+++ b/roles/installer/ospd/images/tasks/update_overcloud_images.yml
@@ -14,7 +14,7 @@
 - name: "create overcloud build's repos locally"
   rhos_release:
       state: install
-      core_version: "{{ installer.product.core.version }}"
+      core_version: "{{ (installer.product.core.version is defined and installer.product.core.version) | ternary(installer.product.core.version, installer.product.version) }}"
       core_build_date: "{{ installer.product.core.build }}"
       target_directory: "{{ tmp_oc_repos_dir }}"
   register: command_result

--- a/settings/installer/ospd/ospd.spec
+++ b/settings/installer/ospd/ospd.spec
@@ -55,9 +55,8 @@ subparsers:
 
                   product-core-version:
                       type: Value
-                      help: The product core version (product-core == overcloud)
+                      help: The product core version (product-core == overcloud). If not supplied, same version as 'product-version' will be used.
                       choices: ["7", "8", "9", "10"]
-                      default: 9
 
                   product-core-build:
                       type: Value


### PR DESCRIPTION
Deafult version of 'product-core-version' parameter in OSPD installer
will be same as 'product-version' if not given.

RHOSINFRA-403